### PR TITLE
release workflow

### DIFF
--- a/.github/workflows/cron-release.yml
+++ b/.github/workflows/cron-release.yml
@@ -1,0 +1,92 @@
+name: 'cron-release'
+
+on:
+  # FIXME: manual run
+  workflow_dispatch:
+  # run daily, 3:00 UTC
+  schedule:
+    - cron: '56 2 * * *'
+
+jobs:
+  pr-checks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Checkout pulp-ui (main)'
+        uses: actions/checkout@v4
+        with:
+          ref: 'main'
+          fetch-depth: 128
+
+      - name: 'Skip if no real changes since last npm version update'
+        run: |
+          LAST=`git blame package.json | grep '"version":' | awk '{ print $1 }'`
+          git diff --exit-code "$LAST" -- src/ package.json
+
+      - name: 'Install node 20'
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      # FIXME: reuse pr-checks.yml?
+      - name: 'Checks'
+        run: |
+          # fail if npm install had to change package-lock.json
+          npm install
+          git diff --exit-code package-lock.json
+
+          # dependencies
+          npm run lint-setup
+
+          # run linters
+          npm run lint
+
+          # run test
+          npm run test
+
+      - name: 'Set PULP_UI_VERSION'
+        run: |
+          # used in npm run build
+          echo "PULP_UI_VERSION=$(git rev-parse HEAD)" >> $GITHUB_ENV
+
+      - name: "git config"
+        run: |
+          git config --local user.name "cron-release workflow"
+          git config --local user.email "pulp-ui+cron-release@example.com"
+
+      # FIXME: reuse i18n.yml? replace?
+      - name: 'Update gettext'
+        run: |
+          npm run gettext:extract
+          npm run gettext:compile
+          git add locale/
+          git commit -m "locale update on $(date --iso=d)" || true
+
+      - name: 'Increment npm version, version tag'
+        run: 'npm version patch'
+
+      - name: 'Set NPM_VERSION, TARBALL'
+        run: |
+          echo "NPM_VERSION=$(jq -r .version < package.json)" >> $GITHUB_ENV
+          echo "TARBALL=pulp-ui-$(date --iso=d).tar.gz" >> $GITHUB_ENV
+
+      - name: 'Build UI dist/'
+        run: 'npm run build'
+
+      - name: "Build a tarball"
+        run: |
+          tar -C dist/ -czvf "$TARBALL" .
+
+      - name: "Push, push tags"
+        run: |
+          # FIXME: git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/pulp/pulp-ui.git
+          # git push -u origin
+          git push
+          git push -f --tags
+
+      - name: "Release"
+        run: |
+          gh release create -p v"$NPM_VERSION" --title "pulp-ui $NPM_VERSION $(date --iso=d)" || true # may already exist
+          gh release upload v"$NPM_VERSION" "$TARBALL" --clobber
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -34,7 +34,7 @@ jobs:
       run: |
         git config --global user.name 'GH Actions'
         git config --global user.email 'gh_actions@users.noreply.github.com'
-        git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/himdel/pulp-ui.git
+        git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/pulp/pulp-ui.git
         git add locale/
         if git commit -m "Automated updated of i18n strings on $(date +'%Y-%m-%d')"; then
           git push --set-upstream origin

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,3 @@
-*.json
 *.md
 *.mp4
 *.png

--- a/config/shared.config.js
+++ b/config/shared.config.js
@@ -12,10 +12,14 @@ const webpack = require('webpack');
 
 const isBuild = process.env.NODE_ENV === 'production';
 
-// only run git when PULP_UI_VERSION is NOT provided
-const gitCommit =
-  process.env.PULP_UI_VERSION ||
-  execSync('git rev-parse HEAD', { encoding: 'utf-8' }).trim();
+// only run git when PULP_UI_COMMIT is NOT provided
+const buildInfo = {
+  hash:
+    process.env.PULP_UI_COMMIT ||
+    execSync('git rev-parse HEAD', { encoding: 'utf-8' }).trim(),
+  date: execSync('date --iso=d', { encoding: 'utf-8' }).trim(),
+  version: require('../package.json').version,
+};
 
 const docsURL = 'https://docs.pulpproject.org/';
 
@@ -27,7 +31,7 @@ const defaultConfigs = [
   { name: 'API_HOST', default: '', scope: 'global' },
   { name: 'APPLICATION_NAME', default: 'Pulp UI', scope: 'global' },
   { name: 'UI_BASE_PATH', default: '', scope: 'global' },
-  { name: 'UI_COMMIT_HASH', default: gitCommit, scope: 'global' },
+  { name: 'UI_BUILD_INFO', default: buildInfo, scope: 'global' },
   { name: 'UI_DOCS_URL', default: docsURL, scope: 'global' },
   { name: 'UI_EXTERNAL_LOGIN_URI', default: '/login', scope: 'global' },
 

--- a/package.json
+++ b/package.json
@@ -91,7 +91,8 @@
     "prettier": "prettier --write 'src/**' 'config/**' 'cypress/**'",
     "prettier:check": "prettier -l 'src/**' 'config/**' 'cypress/**'",
     "sort-exports": "perl -i -pe 's/^export/import/' src/**/index.ts ; npm run prettier ; perl -i -pe 's/^import/export/' src/**/index.ts",
-    "start": "NODE_ENV=development webpack serve --config config/start.config.js"
+    "start": "NODE_ENV=development webpack serve --config config/start.config.js",
+    "test": "true"
   },
   "engines": {
     "node": ">=20",

--- a/src/components/pulp-about-modal.tsx
+++ b/src/components/pulp-about-modal.tsx
@@ -10,7 +10,7 @@ import {
 import React, { type ReactNode, useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { ApplicationInfoAPI } from 'src/api';
-import { ExternalLink, MaybeLink } from 'src/components';
+import { DateComponent, ExternalLink, MaybeLink } from 'src/components';
 import { Paths, formatPath } from 'src/paths';
 import PulpLogo from 'static/images/pulp_logo.png';
 
@@ -56,7 +56,9 @@ export const PulpAboutModal = ({ isOpen, onClose, userName }: IProps) => {
   } = applicationInfo;
 
   const galaxy_ng_sha = galaxy_ng_commit?.split(':')[1];
-  const ui_sha = UI_COMMIT_HASH?.slice(0, 7);
+  const ui_sha = UI_BUILD_INFO?.hash?.slice(0, 7);
+  const ui_date = UI_BUILD_INFO?.date;
+  const ui_version = UI_BUILD_INFO?.version;
 
   // FIXME
   const user = { username: userName, id: null, groups: [] };
@@ -143,10 +145,20 @@ export const PulpAboutModal = ({ isOpen, onClose, userName }: IProps) => {
           <Label>{t`UI Version`}</Label>
           <Value>
             <ExternalLink
-              href={`https://github.com/himdel/pulp-ui/commit/${ui_sha}`}
+              href={`https://github.com/pulp/pulp-ui/commit/${ui_sha}`}
             >
               {ui_sha}
-            </ExternalLink>
+            </ExternalLink>{' '}
+            {ui_version ? (
+              <>
+                <ExternalLink
+                  href={`https://github.com/pulp/pulp-ui/releases/tag/v${ui_version}`}
+                >
+                  {ui_version}
+                </ExternalLink>{' '}
+              </>
+            ) : null}
+            <DateComponent date={ui_date} />
           </Value>
 
           <Label>{t`Username`}</Label>

--- a/src/components/ui-version.tsx
+++ b/src/components/ui-version.tsx
@@ -9,5 +9,8 @@ const HTMLComment = ({ text, ...props }: IProps) => (
 );
 
 export const UIVersion = () => (
-  <HTMLComment id='pulp-ui-version' text={`pulp-ui ${UI_COMMIT_HASH}`} />
+  <HTMLComment
+    id='pulp-ui-version'
+    text={`pulp-ui ${JSON.stringify(UI_BUILD_INFO, null, 2)}`}
+  />
 );

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -9,6 +9,6 @@ declare var API_BASE_PATH;
 declare var API_HOST;
 declare var APPLICATION_NAME;
 declare var UI_BASE_PATH;
-declare var UI_COMMIT_HASH;
+declare var UI_BUILD_INFO;
 declare var UI_DOCS_URL;
 declare var UI_EXTERNAL_LOGIN_URI;


### PR DESCRIPTION
Adds a workflow that doesn't actually npm publish yet, but does all the steps before that, including a npm publish dry run.

It skips a release when nothing changed since the last one - but only in `src/` or `package.json`.
It skips a release when linters or tests fail (tests just run `true` for now).
It bumps the version, updates gettext, builds the UI.

Publishes a github release, with an artifact, and pushes back updated l10n and the tag.