### PR TITLE
Add utility function has_plugins

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@patternfly/react-table": "^5.4.0",
         "axios": "^1.7.7",
         "classnames": "^2.5.1",
+        "compare-versions": "^6.1.1",
         "file-saver": "^2.0.5",
         "js-cookie": "^3.0.5",
         "lodash": "^4.17.21",
@@ -5310,6 +5311,11 @@
       "engines": {
         "node": ">=4.0.0"
       }
+    },
+    "node_modules/compare-versions": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-6.1.1.tgz",
+      "integrity": "sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg=="
     },
     "node_modules/compressible": {
       "version": "2.0.18",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@patternfly/react-table": "^5.4.0",
     "axios": "^1.7.7",
     "classnames": "^2.5.1",
+    "compare-versions": "^6.1.1",
     "file-saver": "^2.0.5",
     "js-cookie": "^3.0.5",
     "lodash": "^4.17.21",

--- a/src/api/pulp-status.ts
+++ b/src/api/pulp-status.ts
@@ -1,8 +1,21 @@
 import { PulpAPI } from './pulp';
 
 export class API extends PulpAPI {
-  get() {
+  last_status = null;
+  last_status_time = 0;
+  private _get() {
     return this.http.get('status');
+  }
+  get() {
+    this.last_status_time = Date.now();
+    this.last_status = this._get();
+    return this.last_status;
+  }
+  cache() {
+    if (!this.last_status || this.last_status_time + 300000 < Date.now()) {
+      return this.get();
+    }
+    return this.last_status;
   }
 }
 

--- a/src/utilities/plugin-version.ts
+++ b/src/utilities/plugin-version.ts
@@ -1,0 +1,38 @@
+import { satisfies } from 'compare-versions';
+import { PulpStatusAPI } from 'src/api';
+
+interface PluginVersion {
+  name: string;
+  version: string;
+}
+
+interface PluginRequirement {
+  name: string;
+  feature?: string;
+  specifier?: string;
+}
+
+export function plugin_versions(): Promise<PluginVersion[]> {
+  return PulpStatusAPI.cache().then(({ data }) =>
+    data.versions.map(({ component, version }) => ({
+      name: component,
+      version: version,
+    })),
+  );
+}
+
+export function has_plugins(
+  plugin_requirements: PluginRequirement[],
+): Promise<boolean> {
+  return plugin_versions().then((versions) => {
+    const map_versions = new Map(
+      versions.map(({ name, version }) => [name, version]),
+    );
+    const present = (req) =>
+      map_versions.has(req.name) &&
+      (req.specifier
+        ? satisfies(map_versions.get(req.name), req.specifier)
+        : true);
+    return plugin_requirements.every(present);
+  });
+}


### PR DESCRIPTION
We have this utility function in pulp-glue which is useful to prevent users from running commands that their pulp doesn't support. Maybe we can have a similar ability for the ui to not show pages for plugins the pulp doesn't have.