### PR TITLE
Add basic docs to show on Pulp website

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # pulp-ui
-a community driven UI for [Pulp](https://pulpproject.org/)
+
+A community driven UI for [Pulp](https://pulpproject.org/).
 
 ## How to run
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,1 @@
+../README.md


### PR DESCRIPTION
Hey @himdel and @ZitaNemeckova !

I'm just adding the basic structure to this.
Along with [this pulp-docs PR,](https://github.com/pulp/pulp-docs/pull/92) it will make pulp-ui `README.md` (relative symlink) to show in the documentation website under `https://pulpproject.org/pulp-ui/`. To stop publishing it, just revert that in `pulp-docs`.

If you decide to setup some changelog tool, pulp-docs will add a `CHANGES.md` (expected to be in the root) to the docs.

I guess because the UI is supposed to be intuitive, you might not need too much docs, but if you want you can create specific docs under `docs/users/`, `docs/admin/` or `docs/dev/` to address specific audiences.

The new docs also proposes using [diataxis](https://diataxis.fr/) categories to help organize the purpose of some content (e.g [in pulpcore](https://github.com/pulp/pulpcore/tree/main/docs)).

Anyway, you can ping me for any doc-related stuff!