### PR TITLE
Add new PulpCodeBlock component that auto-truncates and has download + copy action

### DIFF
--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -104,6 +104,8 @@ export { PreviewRoles } from './preview-roles';
 export { ProviderLink } from './provider-link';
 export { PulpAboutModal } from './pulp-about-modal';
 export { PulpCopyButton } from './pulp-copy-button';
+export { PulpCodeBlock } from './pulp-code-block';
+export { PulpDownloadButton } from './pulp-download-button';
 export { PulpLabels } from './pulp-labels';
 export { PulpListToolbar } from './pulp-list-toolbar';
 export { PulpPagination } from './pulp-pagination';

--- a/src/components/pulp-code-block.tsx
+++ b/src/components/pulp-code-block.tsx
@@ -1,10 +1,21 @@
-import {CodeBlock, CodeBlockAction, CodeBlockCode, ExpandableSection} from "@patternfly/react-core";
-import {PulpCopyButton} from "src/components/pulp-copy-button";
-import {PulpDownloadButton} from "src/components/pulp-download-button";
-import {t} from "@lingui/macro";
-import React from "react";
+import { t } from '@lingui/macro';
+import {
+  CodeBlock,
+  CodeBlockAction,
+  CodeBlockCode,
+  ExpandableSection,
+} from '@patternfly/react-core';
+import React from 'react';
+import { PulpCopyButton } from 'src/components/pulp-copy-button';
+import { PulpDownloadButton } from 'src/components/pulp-download-button';
 
-export const PulpCodeBlock = ({ code, filename }: { code: string, filename?: string }) => {
+export const PulpCodeBlock = ({
+  code,
+  filename,
+}: {
+  code: string;
+  filename?: string;
+}) => {
   const name = filename ? filename : 'pulpui-codeblock-download';
   const actions = (
     <CodeBlockAction>

--- a/src/components/pulp-code-block.tsx
+++ b/src/components/pulp-code-block.tsx
@@ -1,0 +1,28 @@
+import {CodeBlock, CodeBlockAction, CodeBlockCode, ExpandableSection} from "@patternfly/react-core";
+import {PulpCopyButton} from "src/components/pulp-copy-button";
+import {PulpDownloadButton} from "src/components/pulp-download-button";
+import {t} from "@lingui/macro";
+import React from "react";
+
+export const PulpCodeBlock = ({ code, filename }: { code: string, filename?: string }) => {
+  const name = filename ? filename : 'pulpui-codeblock-download';
+  const actions = (
+    <CodeBlockAction>
+      <PulpDownloadButton text={code} filename={name} />
+      <PulpCopyButton text={code} />
+    </CodeBlockAction>
+  );
+
+  return (
+    <ExpandableSection
+      variant='truncate'
+      truncateMaxLines={3}
+      toggleTextCollapsed={t`Show more`}
+      toggleTextExpanded={t`Show less`}
+    >
+      <CodeBlock actions={actions}>
+        <CodeBlockCode>{code}</CodeBlockCode>
+      </CodeBlock>
+    </ExpandableSection>
+  );
+};

--- a/src/components/pulp-download-button.tsx
+++ b/src/components/pulp-download-button.tsx
@@ -1,7 +1,8 @@
-import React from 'react';
-import DownloadIcon from '@patternfly/react-icons/dist/esm/icons/download-icon';
+import { t } from '@lingui/macro';
 import { Button } from '@patternfly/react-core';
-import { downloadString } from "src/utilities";
+import DownloadIcon from '@patternfly/react-icons/dist/esm/icons/download-icon';
+import React from 'react';
+import { downloadString } from 'src/utilities';
 
 export const PulpDownloadButton = ({
   text,
@@ -10,11 +11,10 @@ export const PulpDownloadButton = ({
   text: string;
   filename: string;
 }) => {
-
   return (
     <Button
       variant='plain'
-      aria-label={filename + '-download'}
+      aria-label={t`Download ${filename}`}
       onClick={() => downloadString(text, filename)}
     >
       <DownloadIcon />

--- a/src/components/pulp-download-button.tsx
+++ b/src/components/pulp-download-button.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import DownloadIcon from '@patternfly/react-icons/dist/esm/icons/download-icon';
+import { Button } from '@patternfly/react-core';
+import { downloadString } from "src/utilities";
+
+export const PulpDownloadButton = ({
+  text,
+  filename,
+}: {
+  text: string;
+  filename: string;
+}) => {
+
+  return (
+    <Button
+      variant='plain'
+      aria-label={filename + '-download'}
+      onClick={() => downloadString(text, filename)}
+    >
+      <DownloadIcon />
+    </Button>
+  );
+};

--- a/src/containers/ansible-remote/tab-details.tsx
+++ b/src/containers/ansible-remote/tab-details.tsx
@@ -13,7 +13,7 @@ interface TabProps {
   actionContext: object;
 }
 
-const MaybeCode = ({ code, filename }: { code: string, filename: string }) =>
+const MaybeCode = ({ code, filename }: { code: string; filename: string }) =>
   code ? <PulpCodeBlock code={code} filename={filename} /> : <>{t`None`}</>;
 
 export const DetailsTab = ({ item }: TabProps) => (
@@ -32,8 +32,21 @@ export const DetailsTab = ({ item }: TabProps) => (
         label: t`TLS validation`,
         value: item?.tls_validation ? t`Enabled` : t`Disabled`,
       },
-      { label: t`Client certificate`, value: <MaybeCode code={item?.client_cert} filename={item.name + '-client_cert'} /> },
-      { label: t`CA certificate`, value: <MaybeCode code={item?.ca_cert} filename={item.name + '-ca_cert'} /> },
+      {
+        label: t`Client certificate`,
+        value: (
+          <MaybeCode
+            code={item?.client_cert}
+            filename={item.name + '-client_cert'}
+          />
+        ),
+      },
+      {
+        label: t`CA certificate`,
+        value: (
+          <MaybeCode code={item?.ca_cert} filename={item.name + '-ca_cert'} />
+        ),
+      },
       {
         label: t`Download concurrency`,
         value: item?.download_concurrency ?? t`None`,
@@ -45,7 +58,12 @@ export const DetailsTab = ({ item }: TabProps) => (
       },
       {
         label: t`YAML requirements`,
-        value: <MaybeCode code={item?.requirements_file} filename={item.name + '-requirements.yml'} />,
+        value: (
+          <MaybeCode
+            code={item?.requirements_file}
+            filename={item.name + '-requirements.yml'}
+          />
+        ),
       },
     ]}
   />

--- a/src/containers/ansible-remote/tab-details.tsx
+++ b/src/containers/ansible-remote/tab-details.tsx
@@ -1,16 +1,11 @@
 import { t } from '@lingui/macro';
-import {
-  CodeBlock,
-  CodeBlockAction,
-  CodeBlockCode,
-} from '@patternfly/react-core';
 import React from 'react';
 import { type AnsibleRemoteType } from 'src/api';
 import {
   CopyURL,
   Details,
   LazyRepositories,
-  PulpCopyButton,
+  PulpCodeBlock,
 } from 'src/components';
 
 interface TabProps {
@@ -18,22 +13,8 @@ interface TabProps {
   actionContext: object;
 }
 
-const PFCodeBlock = ({ code }: { code: string }) => {
-  const actions = (
-    <CodeBlockAction>
-      <PulpCopyButton text={code} textId='code-content' />
-    </CodeBlockAction>
-  );
-
-  return (
-    <CodeBlock actions={actions}>
-      <CodeBlockCode id='code-content'>{code}</CodeBlockCode>
-    </CodeBlock>
-  );
-};
-
-const MaybeCode = ({ code }: { code: string }) =>
-  code ? <PFCodeBlock code={code} /> : <>{t`None`}</>;
+const MaybeCode = ({ code, filename }: { code: string, filename: string }) =>
+  code ? <PulpCodeBlock code={code} filename={filename} /> : <>{t`None`}</>;
 
 export const DetailsTab = ({ item }: TabProps) => (
   <Details
@@ -51,8 +32,8 @@ export const DetailsTab = ({ item }: TabProps) => (
         label: t`TLS validation`,
         value: item?.tls_validation ? t`Enabled` : t`Disabled`,
       },
-      { label: t`Client certificate`, value: item?.client_cert || t`None` },
-      { label: t`CA certificate`, value: item?.ca_cert || t`None` },
+      { label: t`Client certificate`, value: <MaybeCode code={item?.client_cert} filename={item.name + '-client_cert'} /> },
+      { label: t`CA certificate`, value: <MaybeCode code={item?.ca_cert} filename={item.name + '-ca_cert'} /> },
       {
         label: t`Download concurrency`,
         value: item?.download_concurrency ?? t`None`,
@@ -64,7 +45,7 @@ export const DetailsTab = ({ item }: TabProps) => (
       },
       {
         label: t`YAML requirements`,
-        value: <MaybeCode code={item?.requirements_file} />,
+        value: <MaybeCode code={item?.requirements_file} filename={item.name + '-requirements.yml'} />,
       },
     ]}
   />


### PR DESCRIPTION
This should make viewing large code fields like certs much prettier.