### PR TITLE
Make API_BASE_PATH, UI_BASE_PATH, UI_EXTERNAL_LOGIN_URI configurable at load-time

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,3 +69,18 @@ npm run start
 ```
 
 and open http://localhost:8002/ :tada: :)
+
+If your API listens elsewhere, you can use `API_PROXY=http://elsewhere:12345 npm run start` instead.
+
+
+## Misc
+
+### post-build configuration
+
+The UI builds produced by `npm run build` can be further configured by serving a `/pulp-ui-config.json` alongside the built UI.
+(Note it has to be mapped at `/`, not just wherever `index.html` is served from.)
+
+* `API_BASE_PATH` - defaults to `/pulp/api/v3/` - change when using domains or a different path
+* `UI_BASE_PATH` - defaults to `/ui/` - change when only serving index in a subdirectory, or want different browser path prefix
+* `UI_EXTERNAL_LOGIN_URI` - defaults to nothing - set to something like `/login/` when using an SSO
+* `EXTRA_VERSION` - an extra version string to display in about modal

--- a/config/build.config.js
+++ b/config/build.config.js
@@ -1,9 +1,5 @@
 const webpackBase = require('./shared.config');
 
-// Compile configuration for stnadalone mode
 module.exports = webpackBase({
-  API_BASE_PATH: '/pulp/api/v3/',
-  UI_BASE_PATH: '/ui/',
-  UI_USE_HTTPS: false,
   WEBPACK_PUBLIC_PATH: '/static/pulp_ui/',
 });

--- a/config/start.config.js
+++ b/config/start.config.js
@@ -1,31 +1,18 @@
 const webpackBase = require('./shared.config');
 
-// Used for getting the correct host when running in a container
-const proxyHost = process.env.API_PROXY_HOST || 'localhost';
-const proxyPort = process.env.API_PROXY_PORT || '8080';
-const apiBasePath = process.env.API_BASE_PATH || '/pulp/api/v3/';
-const proxyTarget = `http://${proxyHost}:${proxyPort}`;
+const proxyTarget = process.env.API_PROXY || 'http://localhost:8080';
 
 module.exports = webpackBase({
-  // The host where the API lives. EX: http://localhost:8080
-  API_HOST: '',
-
-  // Path to the API on the API host. EX: /pulp/api/v3
-  API_BASE_PATH: apiBasePath,
-
-  // Path on the host where the UI is found. EX: /ui/
-  UI_BASE_PATH: '/ui/',
-
   // Port that the UI is served over.
-  UI_PORT: 8002,
+  DEV_PORT: 8002,
 
   // Serve the UI over http or https. Options: true, false
-  UI_USE_HTTPS: false,
+  DEV_HTTPS: false,
 
   // Value for webpack.devServer.proxy
   // https://webpack.js.org/configuration/dev-server/#devserverproxy
   // used to get around CORS requirements when running in dev mode
-  WEBPACK_PROXY: {
+  DEV_PROXY: {
     '/api/': proxyTarget,
     '/assets/': proxyTarget,
     '/extensions/': proxyTarget,

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
         "babel-plugin-macros": "^3.1.0",
         "chrome-remote-interface": "^0.33.2",
         "clean-webpack-plugin": "^4.0.0",
+        "copy-webpack-plugin": "^12.0.2",
         "css-loader": "^7.1.2",
         "cypress": "^13.15.0",
         "cypress-file-upload": "^5.0.8",
@@ -3036,6 +3037,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@sindresorhus/merge-streams": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-2.3.0.tgz",
+      "integrity": "sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@trivago/prettier-plugin-sort-imports": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/@trivago/prettier-plugin-sort-imports/-/prettier-plugin-sort-imports-4.3.0.tgz",
@@ -5391,6 +5405,91 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
       "dev": true
+    },
+    "node_modules/copy-webpack-plugin": {
+      "version": "12.0.2",
+      "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-12.0.2.tgz",
+      "integrity": "sha512-SNwdBeHyII+rWvee/bTnAYyO8vfVdcSTud4EIb6jcZ8inLeWucJE0DnxXQBjlQ5zlteuuvooGQy3LIyGxhvlOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-glob": "^3.3.2",
+        "glob-parent": "^6.0.1",
+        "globby": "^14.0.0",
+        "normalize-path": "^3.0.0",
+        "schema-utils": "^4.2.0",
+        "serialize-javascript": "^6.0.2"
+      },
+      "engines": {
+        "node": ">= 18.12.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^5.1.0"
+      }
+    },
+    "node_modules/copy-webpack-plugin/node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/copy-webpack-plugin/node_modules/globby": {
+      "version": "14.0.2",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-14.0.2.tgz",
+      "integrity": "sha512-s3Fq41ZVh7vbbe2PN3nrW7yC7U7MFVc5c98/iTl9c2GawNMKx/J648KQRW6WKkuU8GIbbh2IXfIRQjOZnXcTnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/merge-streams": "^2.1.0",
+        "fast-glob": "^3.3.2",
+        "ignore": "^5.2.4",
+        "path-type": "^5.0.0",
+        "slash": "^5.1.0",
+        "unicorn-magic": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/copy-webpack-plugin/node_modules/path-type": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-5.0.0.tgz",
+      "integrity": "sha512-5HviZNaZcfqP95rwpv+1HDgUamezbqdSYTyzjTvwtJSnIH+3vnbmWsItli8OFEndS984VT55M3jduxZbX351gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/copy-webpack-plugin/node_modules/slash": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
+      "integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/core-js-compat": {
       "version": "3.38.1",
@@ -14545,6 +14644,19 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/unicorn-magic": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.1.0.tgz",
+      "integrity": "sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/unified": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "babel-plugin-macros": "^3.1.0",
     "chrome-remote-interface": "^0.33.2",
     "clean-webpack-plugin": "^4.0.0",
+    "copy-webpack-plugin": "^12.0.2",
     "css-loader": "^7.1.2",
     "cypress": "^13.15.0",
     "cypress-file-upload": "^5.0.8",

--- a/pulp-ui-config.json
+++ b/pulp-ui-config.json
@@ -1,0 +1,6 @@
+{
+  "API_BASE_PATH": "/pulp/api/v3/",
+  "UI_BASE_PATH": "/ui/",
+  "UI_EXTERNAL_LOGIN_URI": null,
+  "EXTRA_VERSION": ""
+}

--- a/src/api/base.ts
+++ b/src/api/base.ts
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import Cookies from 'js-cookie';
+import { config } from 'src/ui-config';
 import { ParamHelper } from 'src/utilities';
 
 export class BaseAPI {
@@ -10,17 +11,16 @@ export class BaseAPI {
   mapPageToOffset: boolean;
 
   // a request URL is created from:
-  // * API_HOST - optional, for use with different hostname
-  // * apiBaseUrl - api/pulp prefix, ends in trailing slash
+  // * API_BASE_PATH - pulp api prefix, ends in trailing slash
   // * apiPath - set by leaf API classes
   // any extra id or params added by custom methods
-  constructor(apiBaseUrl) {
+  constructor() {
     this.http = axios.create({
       // adapter + withCredentials ensures no popup on http basic auth fail
       adapter: 'fetch',
       withCredentials: false,
 
-      baseURL: API_HOST + apiBaseUrl,
+      // baseURL set to API_BASE_PATH in authHandler
       paramsSerializer: {
         serialize: (params) => ParamHelper.getQueryString(params),
       },
@@ -88,7 +88,6 @@ export class BaseAPI {
   }
 
   private async authHandler(request) {
-    request.headers['X-CSRFToken'] = Cookies.get('csrftoken');
     if (!request.auth) {
       request.auth = JSON.parse(
         window.sessionStorage.credentials ||
@@ -96,6 +95,8 @@ export class BaseAPI {
           '{}',
       );
     }
+    request.baseURL = config.API_BASE_PATH;
+    request.headers['X-CSRFToken'] = Cookies.get('csrftoken');
     return request;
   }
 }

--- a/src/api/certificate-upload.ts
+++ b/src/api/certificate-upload.ts
@@ -11,7 +11,7 @@ interface UploadProps {
 class API extends PulpAPI {
   apiPath = 'content/ansible/collection_signatures/';
 
-  // Returns /api/automation-hub/pulp/api/v3/tasks/0be64cb4-3b7e-4a6b-b35d-c3b589923a90/
+  // Returns /pulp/api/v3/tasks/0be64cb4-3b7e-4a6b-b35d-c3b589923a90/
   upload(data: UploadProps): Promise<{ data: { task: string } }> {
     const formData = new FormData();
     formData.append('file', data.file);

--- a/src/api/hub.ts
+++ b/src/api/hub.ts
@@ -3,8 +3,4 @@ import { BaseAPI } from './base';
 export class HubAPI extends BaseAPI {
   mapPageToOffset = true; // offset & limit
   sortParam = 'sort';
-
-  constructor() {
-    super(API_BASE_PATH);
-  }
 }

--- a/src/api/pulp.ts
+++ b/src/api/pulp.ts
@@ -3,8 +3,4 @@ import { BaseAPI } from './base';
 export class PulpAPI extends BaseAPI {
   mapPageToOffset = true; // offset & limit
   sortParam = 'ordering';
-
-  constructor() {
-    super(API_BASE_PATH);
-  }
 }

--- a/src/api/role.ts
+++ b/src/api/role.ts
@@ -1,3 +1,4 @@
+import { config } from 'src/ui-config';
 import { PulpAPI } from './pulp';
 
 export class API extends PulpAPI {
@@ -13,9 +14,9 @@ export class API extends PulpAPI {
   list(params?, for_object_type?) {
     const newParams = { ...params };
     if (for_object_type) {
-      // ?for_object_type=/api/automation-hub/pulp/api/v3/.../
-      // list visible in http://localhost:8002/api/automation-hub/pulp/api/v3/
-      newParams.for_object_type = API_BASE_PATH + for_object_type + '/';
+      // ?for_object_type=/pulp/api/v3/.../
+      // list visible in http://localhost:8002/pulp/api/v3/
+      newParams.for_object_type = config.API_BASE_PATH + for_object_type + '/';
     }
     return super.list(newParams);
   }

--- a/src/app-routes.tsx
+++ b/src/app-routes.tsx
@@ -48,6 +48,8 @@ import {
   UserProfile,
 } from 'src/containers';
 import { Paths, formatPath } from 'src/paths';
+import { config } from 'src/ui-config';
+import { loginURL } from 'src/utilities';
 import { useUserContext } from './user-context';
 
 interface IAuthHandlerProps {
@@ -71,12 +73,11 @@ const AuthHandler = ({
   const { pathname } = useLocation();
 
   if (!credentials && !noAuth) {
-    //const isExternalAuth = featureFlags.external_authentication;
     // NOTE: also update LoginLink when changing this
-    //if (isExternalAuth && UI_EXTERNAL_LOGIN_URI) {
-    //  window.location.replace(loginURL(pathname));
-    //  return null;
-    //}
+    if (config.UI_EXTERNAL_LOGIN_URI) {
+      window.location.replace(loginURL(pathname));
+      return null;
+    }
 
     return (
       <Navigate to={formatPath(Paths.meta.login, {}, { next: pathname })} />

--- a/src/components/login-link.tsx
+++ b/src/components/login-link.tsx
@@ -2,6 +2,8 @@ import { t } from '@lingui/macro';
 import React from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import { Paths, formatPath } from 'src/paths';
+import { config } from 'src/ui-config';
+import { loginURL } from 'src/utilities';
 
 interface IProps {
   button?: boolean;
@@ -9,15 +11,16 @@ interface IProps {
 
 export const LoginLink = ({ button }: IProps) => {
   const { pathname } = useLocation();
+  const className = button ? 'pf-v5-c-button pf-m-primary' : '';
 
   // NOTE: also update AuthHandler#render (src/routes.tsx) when changing this
-  //if (featureFlags?.external_authentication && UI_EXTERNAL_LOGIN_URI) {
-  //  return <a className={className} href={loginURL(pathname)}>{t`Login`}</a>;
-  //}
+  if (config.UI_EXTERNAL_LOGIN_URI) {
+    return <a className={className} href={loginURL(pathname)}>{t`Login`}</a>;
+  }
 
   return (
     <Link
-      className={button ? 'pf-v5-c-button pf-m-primary' : ''}
+      className={className}
       to={formatPath(Paths.meta.login, {}, { next: pathname })}
     >{t`Login`}</Link>
   );

--- a/src/components/pulp-about-modal.tsx
+++ b/src/components/pulp-about-modal.tsx
@@ -11,6 +11,7 @@ import React, { type ReactNode, useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { DateComponent, ExternalLink, MaybeLink } from 'src/components';
 import { Paths, formatPath } from 'src/paths';
+import { config } from 'src/ui-config';
 import { plugin_versions } from 'src/utilities';
 import PulpLogo from 'static/images/pulp_logo.png';
 
@@ -50,6 +51,7 @@ export const PulpAboutModal = ({ isOpen, onClose, userName }: IProps) => {
   const ui_sha = UI_BUILD_INFO?.hash?.slice(0, 7);
   const ui_date = UI_BUILD_INFO?.date;
   const ui_version = UI_BUILD_INFO?.version;
+  const ui_extra = config.EXTRA_VERSION;
 
   // FIXME
   const user = { username: userName, id: null, groups: [] };
@@ -97,6 +99,12 @@ export const PulpAboutModal = ({ isOpen, onClose, userName }: IProps) => {
             {', '}
             <DateComponent date={ui_date} />
             {ui_version ? ')' : null}
+            {ui_extra ? (
+              <>
+                <br />
+                {ui_extra}
+              </>
+            ) : null}
           </Value>
 
           <Label>{t`Username`}</Label>

--- a/src/containers/ansible-repository/tab-repository-versions.tsx
+++ b/src/containers/ansible-repository/tab-repository-versions.tsx
@@ -17,6 +17,7 @@ import {
   Spinner,
 } from 'src/components';
 import { Paths, formatPath } from 'src/paths';
+import { config } from 'src/ui-config';
 import { parsePulpIDFromURL } from 'src/utilities';
 
 interface TabProps {
@@ -31,7 +32,7 @@ interface TabProps {
 
 const AnyAPI = (href) =>
   new (class extends PulpAPI {
-    apiPath = href.replace(API_BASE_PATH, '');
+    apiPath = href.replace(config.API_BASE_PATH, '');
   })();
 
 const VersionContent = ({

--- a/src/containers/pulp-status.tsx
+++ b/src/containers/pulp-status.tsx
@@ -46,12 +46,14 @@ const StatusVersions = ({
 
   return (
     <table style={{ width: '100%' }}>
-      {sorted.map(({ component, version }) => (
-        <tr key={component}>
-          <td>{component}</td>
-          <td>{version}</td>
-        </tr>
-      ))}
+      <tbody>
+        {sorted.map(({ component, version }) => (
+          <tr key={component}>
+            <td>{component}</td>
+            <td>{version}</td>
+          </tr>
+        ))}
+      </tbody>
     </table>
   );
 };

--- a/src/containers/task-management/task-detail.tsx
+++ b/src/containers/task-management/task-detail.tsx
@@ -30,6 +30,7 @@ import {
   closeAlert,
 } from 'src/components';
 import { Paths, formatPath } from 'src/paths';
+import { config } from 'src/ui-config';
 import {
   type RouteProps,
   jsxErrorMessage,
@@ -460,7 +461,7 @@ class TaskDetail extends Component<RouteProps, IState> {
         }
         if (result.data.reserved_resources_record.length) {
           result.data.reserved_resources_record.forEach((resource) => {
-            const url = resource.replace(API_BASE_PATH, '');
+            const url = resource.replace(config.API_BASE_PATH, '');
             const id = parsePulpIDFromURL(url);
             const urlParts = url.split('/');
             let resourceType = '';

--- a/src/entrypoint.tsx
+++ b/src/entrypoint.tsx
@@ -1,50 +1,95 @@
 import './app.scss';
 import { i18n } from '@lingui/core';
+import { t } from '@lingui/macro';
 import { I18nProvider } from '@lingui/react';
 import '@patternfly/patternfly/patternfly.scss';
-import React, { StrictMode } from 'react';
+import React, { StrictMode, useEffect, useState } from 'react';
 import { createRoot } from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
-import { UIVersion } from 'src/components';
+import { Alert, LoadingSpinner, UIVersion } from 'src/components';
 import { AppContextProvider } from './app-context';
 import { AppRoutes } from './app-routes';
 import './darkmode';
 import './l10n';
 import { StandaloneLayout } from './layout';
+import { configPromise } from './ui-config';
 import { UserContextProvider } from './user-context';
 
 // App entrypoint
 
-const searchParams = new URLSearchParams(window.location.search);
-if (!window.location.pathname.startsWith(UI_BASE_PATH)) {
-  // react-router v6 won't redirect to base path by default
-  window.history.pushState(null, null, UI_BASE_PATH);
-} else if (searchParams.has('lang') || searchParams.has('pseudolocalization')) {
-  // delete lang after src/l10n uses it
-  searchParams.delete('lang');
-  searchParams.delete('pseudolocalization');
-  window.history.pushState(
-    null,
-    null,
-    window.location.pathname +
-      (searchParams.toString() ? '?' + searchParams.toString() : ''),
-  );
-}
+configPromise.then(({ UI_BASE_PATH }) => {
+  const searchParams = new URLSearchParams(window.location.search);
+  if (!window.location.pathname.startsWith(UI_BASE_PATH)) {
+    // react-router v6 won't redirect to base path by default
+    window.history.pushState(null, null, UI_BASE_PATH);
+  } else if (
+    searchParams.has('lang') ||
+    searchParams.has('pseudolocalization')
+  ) {
+    // delete lang after src/l10n uses it
+    searchParams.delete('lang');
+    searchParams.delete('pseudolocalization');
+    window.history.pushState(
+      null,
+      null,
+      window.location.pathname +
+        (searchParams.toString() ? '?' + searchParams.toString() : ''),
+    );
+  }
+});
 
 const root = createRoot(document.getElementById('root'));
 root.render(
   <StrictMode>
-    <BrowserRouter basename={UI_BASE_PATH}>
-      <I18nProvider i18n={i18n}>
-        <UserContextProvider>
-          <AppContextProvider>
-            <StandaloneLayout>
-              <AppRoutes />
-            </StandaloneLayout>
-            <UIVersion />
-          </AppContextProvider>
-        </UserContextProvider>
-      </I18nProvider>
-    </BrowserRouter>
+    <I18nProvider i18n={i18n}>
+      <LoadConfig />
+    </I18nProvider>
   </StrictMode>,
 );
+
+function LoadConfig(_props) {
+  const [config, setConfig] = useState(null);
+  const [error, setError] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    configPromise
+      .then((config) => {
+        setLoading(false);
+        setConfig(config);
+      })
+      .catch((err) => {
+        setLoading(false);
+        setError(err);
+      });
+  });
+
+  if (loading) {
+    return <LoadingSpinner />;
+  }
+
+  if (error || !config) {
+    return (
+      <Alert
+        variant='danger'
+        isInline
+        title={t`Error loading /pulp-ui-config.json`}
+      >
+        {error}
+      </Alert>
+    );
+  }
+
+  return (
+    <BrowserRouter basename={config.UI_BASE_PATH}>
+      <UserContextProvider>
+        <AppContextProvider>
+          <StandaloneLayout>
+            <AppRoutes />
+          </StandaloneLayout>
+          <UIVersion />
+        </AppContextProvider>
+      </UserContextProvider>
+    </BrowserRouter>
+  );
+}

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -2,13 +2,10 @@
 // This will tell typescript that anything from this module is of type any.
 
 declare module '*.png';
+declare module '*.svg';
 
 // Declare configuration globals here so that TypeScript compiles
 /* eslint-disable no-var */
-declare var API_BASE_PATH;
-declare var API_HOST;
 declare var APPLICATION_NAME;
-declare var UI_BASE_PATH;
 declare var UI_BUILD_INFO;
 declare var UI_DOCS_URL;
-declare var UI_EXTERNAL_LOGIN_URI;

--- a/src/ui-config.ts
+++ b/src/ui-config.ts
@@ -1,0 +1,5 @@
+export const configPromise = fetch('/pulp-ui-config.json').then((data) =>
+  data.json(),
+);
+export let config = null;
+configPromise.then((data) => (config = data));

--- a/src/ui-config.ts
+++ b/src/ui-config.ts
@@ -1,5 +1,13 @@
+import defaults from '../pulp-ui-config.json';
+
 export const configPromise = fetch('/pulp-ui-config.json').then((data) =>
-  data.json(),
+  data.status > 0 && data.status < 300
+    ? data.json()
+    : Promise.reject(`${data.status}: ${data.statusText}`),
 );
+
 export let config = null;
+
+export const configFallback = () => (config = defaults);
+
 configPromise.then((data) => (config = data));

--- a/src/utilities/get-repo-url.ts
+++ b/src/utilities/get-repo-url.ts
@@ -1,13 +1,9 @@
-// Returns the API path for a specific repository
-export function getRepoURL(distribution_base_path, view_published = false) {
-  // If the api is hosted on another URL, use API_HOST as the host part of the URL.
-  // Otherwise use the host that the UI is served from
-  const host = API_HOST ? API_HOST : window.location.origin;
+import { config } from 'src/ui-config';
 
-  // repo/distro "published" is special; not related to repo pipeline type
-  if (distribution_base_path === 'published' && view_published === false) {
-    return `${host}${API_BASE_PATH}`;
-  }
+// Returns the API path for a specific repository
+export function getRepoURL(distribution_base_path) {
+  const host = window.location.origin;
+  const { API_BASE_PATH } = config;
 
   return `${host}${API_BASE_PATH}content/${distribution_base_path}/`;
 }

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -8,6 +8,7 @@ export { filterIsSet } from './filter-is-set';
 export { getHumanSize } from './get-human-size';
 export { getContainersURL, getRepoURL } from './get-repo-url';
 export { lastSyncStatus, lastSynced } from './last-sync-task';
+export { loginURL } from './login-url';
 export {
   ErrorMessagesType,
   alertErrorsWithoutFields,

--- a/src/utilities/login-url.ts
+++ b/src/utilities/login-url.ts
@@ -1,0 +1,13 @@
+import { config } from 'src/ui-config';
+
+// external login URL, assuming UI_EXETRNAL_LOGIN_URI is set
+export const loginURL = (next) => {
+  const { UI_BASE_PATH, UI_EXTERNAL_LOGIN_URI } = config;
+
+  if (next) {
+    const fullPath = `${UI_BASE_PATH}/${next}`.replaceAll(/\/+/g, '/');
+    return `${UI_EXTERNAL_LOGIN_URI}?next=${encodeURIComponent(fullPath)}`;
+  }
+
+  return UI_EXTERNAL_LOGIN_URI;
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,7 @@
       "src/*": ["src/*"],
       "static/*": ["static/*"]
     },
+    "resolveJsonModule": true,
     "skipLibCheck": true,
     "sourceMap": true,
     "strictNullChecks": false,


### PR DESCRIPTION
Closes #93 

The UI builds produced by `npm run build` can be further configured by serving a `/pulp-ui-config.json` alongside the built UI. (Note it has to be mapped at `/`, not just wherever `index.html` is served from.)

* `API_BASE_PATH` - defaults to `/pulp/api/v3/` - change when using domains or a different path
* `UI_BASE_PATH` - defaults to `/ui/` - change when only serving index in a subdirectory, or want different browser path prefix
* `UI_EXTERNAL_LOGIN_URI` - defaults to nothing - set to something like `/login/` when using an SSO
* `EXTRA_VERSION` - an extra version string to display in about modal

Also documents `API_PROXY` in dev mode, and restore SSO logic when `UI_EXTERNAL_LOGIN_URI` is set.

---

default config in `pulp-ui/pulp-ui-config.json` gets copied by `CopyWebpackPlugin` to `dist/`,
and must be served from `/pulp-ui-config.json` in the webserver config for this to work.

`src/ui-config.ts` (imported from `src/entrypoint.tsx`) then loads it and populates a `config` export on success.

entrypoint then ensures we wait for the promise before rendering anything that would need to use that config

Cc @gerrod3 