### PR TITLE
cron-release: add CHANGES.md from autogenerated github release changelog

### DIFF
--- a/.github/workflows/cron-release.yml
+++ b/.github/workflows/cron-release.yml
@@ -105,7 +105,16 @@ jobs:
 
       - name: 'Update CHANGES.md'
         run: |
-          ( curl -s https://api.github.com/repos/pulp/pulp-ui/releases/latest | jq -r '.name,"",.body' | grep -v '^\* Bump .* by @dependabot in ' ; echo ; echo '----'; echo; cat CHANGES.md ) | sponge CHANGES.md
+          (
+            curl -s https://api.github.com/repos/pulp/pulp-ui/releases/latest | \
+            jq -r '.name,"",.body' | \
+            sed -e 's/^## /### /' -e 's/^pulp-ui \(.*\) \(.*\)/## \1 (\2) {: #\1 }/' | \
+            grep -v '^\* Bump .* by @dependabot in '
+            echo
+            echo '---'
+            echo
+            cat CHANGES.md
+          ) | sponge CHANGES.md
           git add CHANGES.md
           git commit -m "changelog update for $NPM_VERSION"
           git push

--- a/.github/workflows/cron-release.yml
+++ b/.github/workflows/cron-release.yml
@@ -39,6 +39,10 @@ jobs:
         with:
           python-version: '3.13'
 
+      - name: 'Install moreutils'
+        run: |
+          apt-get -y install moreutils
+
       # FIXME: reuse pr-checks.yml?
       - name: 'Checks'
         run: |
@@ -98,3 +102,10 @@ jobs:
           gh release upload v"$NPM_VERSION" "$TARBALL" --clobber
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: 'Update CHANGES.md'
+        run: |
+          ( curl -s https://api.github.com/repos/pulp/pulp-ui/releases/latest | jq -r '.name,"",.body' | grep -v '^\* Bump .* by @dependabot in ' ; echo ; echo '----'; echo; cat CHANGES.md ) | sponge CHANGES.md
+          git add CHANGES.md
+          git commit -m "changelog update for $NPM_VERSION"
+          git push

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,57 @@
+pulp-ui 0.1.7 2024-10-19
+
+## What's Changed
+* Remove galaxy info from about modal by @gerrod3 in https://github.com/pulp/pulp-ui/pull/90
+
+
+**Full Changelog**: https://github.com/pulp/pulp-ui/compare/v0.1.6...v0.1.7
+
+----
+
+pulp-ui 0.1.6 2024-10-18
+
+## What's Changed
+* Fix date command for build startup by @gerrod3 in https://github.com/pulp/pulp-ui/pull/94
+* Add Ubuntu update fix by @ZitaNemeckova in https://github.com/pulp/pulp-ui/pull/101
+* Login - add warning about basic auth by @himdel in https://github.com/pulp/pulp-ui/pull/104
+
+
+**Full Changelog**: https://github.com/pulp/pulp-ui/compare/v0.1.5...v0.1.6
+
+----
+
+pulp-ui 0.1.5 2024-10-10
+
+**Full Changelog**: https://github.com/pulp/pulp-ui/compare/v0.1.4...v0.1.5
+
+----
+
+pulp-ui 0.1.4 2024-10-07
+
+## What's Changed
+* RPM list by @himdel in https://github.com/pulp/pulp-ui/pull/72
+
+
+**Full Changelog**: https://github.com/pulp/pulp-ui/compare/v0.1.3...v0.1.4
+
+----
+
+pulp-ui 0.1.3 2024-10-07
+
+## What's Changed
+* Add utility function has\_plugins by @gerrod3 in https://github.com/pulp/pulp-ui/pull/74
+* Paths - reorganize by plugin by @himdel in https://github.com/pulp/pulp-ui/pull/82
+* Filter menu based on plugins by @himdel in https://github.com/pulp/pulp-ui/pull/86
+
+
+**Full Changelog**: https://github.com/pulp/pulp-ui/compare/v0.1.2...v0.1.3
+
+----
+
+pulp-ui 0.1.2 2024-10-01
+
+**Full Changelog**: https://github.com/pulp/pulp-ui/compare/v0.1.1...v0.1.2
+
+----
+
+pulp-ui 0.1.1 2024-10-01

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,16 +1,34 @@
-pulp-ui 0.1.7 2024-10-19
+## 0.1.8 (2024-10-22) {: #0.1.8 }
 
-## What's Changed
+### What's Changed
+* Add basic docs to show on Pulp website by @pedro-psb in https://github.com/pulp/pulp-ui/pull/107
+* User form fixes - convert user edit screens to functional, use user context, update api to patch by @himdel in https://github.com/pulp/pulp-ui/pull/112
+* Add new PulpCodeBlock component that auto-truncates and has download + copy action by @gerrod3 in https://github.com/pulp/pulp-ui/pull/109
+* Add About page by @ZitaNemeckova in https://github.com/pulp/pulp-ui/pull/95
+* Not found handling - switch away from routes by @himdel in https://github.com/pulp/pulp-ui/pull/121
+* Remove galaxy-specifics from ansible repository list & detail tab by @gerrod3 in https://github.com/pulp/pulp-ui/pull/108
+* stylelint - switch to `stylelint-config-recommended-scss` by @himdel in https://github.com/pulp/pulp-ui/pull/122
+
+### New Contributors
+* @pedro-psb made their first contribution in https://github.com/pulp/pulp-ui/pull/107
+
+**Full Changelog**: https://github.com/pulp/pulp-ui/compare/v0.1.7...v0.1.8
+
+---
+
+## 0.1.7 (2024-10-19) {: #0.1.7 }
+
+### What's Changed
 * Remove galaxy info from about modal by @gerrod3 in https://github.com/pulp/pulp-ui/pull/90
 
 
 **Full Changelog**: https://github.com/pulp/pulp-ui/compare/v0.1.6...v0.1.7
 
-----
+---
 
-pulp-ui 0.1.6 2024-10-18
+## 0.1.6 (2024-10-18) {: #0.1.6 }
 
-## What's Changed
+### What's Changed
 * Fix date command for build startup by @gerrod3 in https://github.com/pulp/pulp-ui/pull/94
 * Add Ubuntu update fix by @ZitaNemeckova in https://github.com/pulp/pulp-ui/pull/101
 * Login - add warning about basic auth by @himdel in https://github.com/pulp/pulp-ui/pull/104
@@ -18,27 +36,27 @@ pulp-ui 0.1.6 2024-10-18
 
 **Full Changelog**: https://github.com/pulp/pulp-ui/compare/v0.1.5...v0.1.6
 
-----
+---
 
-pulp-ui 0.1.5 2024-10-10
+## 0.1.5 (2024-10-10) {: #0.1.5 }
 
 **Full Changelog**: https://github.com/pulp/pulp-ui/compare/v0.1.4...v0.1.5
 
-----
+---
 
-pulp-ui 0.1.4 2024-10-07
+## 0.1.4 (2024-10-07) {: #0.1.4 }
 
-## What's Changed
+### What's Changed
 * RPM list by @himdel in https://github.com/pulp/pulp-ui/pull/72
 
 
 **Full Changelog**: https://github.com/pulp/pulp-ui/compare/v0.1.3...v0.1.4
 
-----
+---
 
-pulp-ui 0.1.3 2024-10-07
+## 0.1.3 (2024-10-07) {: #0.1.3 }
 
-## What's Changed
+### What's Changed
 * Add utility function has\_plugins by @gerrod3 in https://github.com/pulp/pulp-ui/pull/74
 * Paths - reorganize by plugin by @himdel in https://github.com/pulp/pulp-ui/pull/82
 * Filter menu based on plugins by @himdel in https://github.com/pulp/pulp-ui/pull/86
@@ -46,12 +64,12 @@ pulp-ui 0.1.3 2024-10-07
 
 **Full Changelog**: https://github.com/pulp/pulp-ui/compare/v0.1.2...v0.1.3
 
-----
+---
 
-pulp-ui 0.1.2 2024-10-01
+## 0.1.2 (2024-10-01) {: #0.1.2 }
 
 **Full Changelog**: https://github.com/pulp/pulp-ui/compare/v0.1.1...v0.1.2
 
-----
+---
 
-pulp-ui 0.1.1 2024-10-01
+## 0.1.1 (2024-10-01) {: #0.1.1 }


### PR DESCRIPTION
A quick solution to https://github.com/pulp/pulp-ui/pull/107#issuecomment-2423085436

Generate `CHANGES.md` from the github release changelog, excluding dependabot PRs.

(It just can't happen before the release, because github creates the release together with a tag, and only generates the changelog after that .. but it will update right after (without triggering a next release))

(is [feed.pulp](https://github.com/himdel/feed.pulp/blob/main/pulp-changes.rb#L34-L57) the only parser?)