### PR TITLE
Add ability to add/edit/remove pulp labels

### DIFF
--- a/src/components/ansible-repository-form.tsx
+++ b/src/components/ansible-repository-form.tsx
@@ -13,6 +13,7 @@ import {
   FormFieldHelper,
   HelpButton,
   LazyDistributions,
+  PulpLabels,
   Spinner,
   Typeahead,
 } from 'src/components';
@@ -161,6 +162,28 @@ export const AnsibleRepositoryForm = ({
             label={t`Create a "${repository.name}" distribution`}
             id='create_distribution'
           />
+        </>,
+      )}
+
+      {formGroup(
+        'pulp_labels',
+        t`Labels`,
+        t`Pulp Labels in the form of 'key:value'.`,
+        <>
+          <div
+            // prevents "N more" clicks from submitting the form
+            onClick={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+            }}
+          >
+            <PulpLabels
+              labels={repository.pulp_labels}
+              updateLabels={(labels) =>
+                updateRepository({ ...repository, pulp_labels: labels })
+              }
+            />
+          </div>
         </>,
       )}
 

--- a/src/components/pulp-labels.tsx
+++ b/src/components/pulp-labels.tsx
@@ -1,21 +1,112 @@
 import { t } from '@lingui/macro';
-import { Label } from '@patternfly/react-core';
+import { Button, Label } from '@patternfly/react-core';
+import InfoCircleIcon from '@patternfly/react-icons/dist/esm/icons/info-circle-icon';
+import PlusCircleIcon from '@patternfly/react-icons/dist/esm/icons/plus-circle-icon';
 import React from 'react';
 import { LabelGroup } from 'src/components';
 
-export const PulpLabels = ({ labels }: { labels: Record<string, string> }) => {
-  if (!labels || !Object.keys(labels).length) {
-    return <>{t`None`}</>;
-  }
+interface Label {
+  key: string;
+  value: string;
+  id: number;
+  valid: boolean;
+}
 
-  return (
+export const PulpLabels = ({
+  labels,
+  updateLabels,
+}: {
+  labels: Record<string, string>;
+  updateLabels?: (l) => void;
+}) => {
+  const [labelS, setLabels] = React.useState(
+    !labels || !Object.keys(labels).length
+      ? []
+      : Object.entries(labels).map(([k, v], i) => ({
+          key: k,
+          value: v,
+          id: i,
+          valid: true,
+        })),
+  );
+  const [idIndex, setIdIndex] = React.useState(labelS.length);
+  const update = (newLabels: Label[]) => {
+    const newLabelsObj = newLabels.reduce(
+      (o, label) => ({ ...o, [label.key]: label.value }),
+      {},
+    );
+    updateLabels(newLabelsObj);
+  };
+
+  const onClose = (labelId: number) => {
+    const newLabels = labelS
+      .filter((l) => l.id !== labelId)
+      .map((v, i) => ({ ...v, id: i }));
+    update(newLabels);
+    setLabels(newLabels);
+    setIdIndex(newLabels.length);
+  };
+
+  const onEdit = (newText: string, index: number) => {
+    const copy = [...labelS];
+    const [k, v] = newText.split(':', 2);
+    const [ks, vs] = [k.trim(), v ? v.trim() : ''];
+    const valid = !!ks.match(/^[\w ]+$/) && vs.search(/[,()]/) == -1;
+    copy[index] = { key: ks, value: vs, id: labelS[index].id, valid: valid };
+    update(copy);
+    setLabels(copy);
+  };
+
+  const onAdd = () => {
+    const newLabels = [
+      ...labelS,
+      { key: 'key', value: 'value', id: idIndex, valid: true },
+    ];
+    update(newLabels);
+    setLabels(newLabels);
+    setIdIndex(idIndex + 1);
+  };
+
+  return updateLabels ? (
+    <LabelGroup
+      isEditable
+      addLabelControl={
+        <Button variant='plain' aria-label='Create new label' onClick={onAdd}>
+          <PlusCircleIcon />
+        </Button>
+      }
+      style={{ alignItems: 'center' }}
+    >
+      {labelS.length ? (
+        labelS.map(({ key, value, id, valid }) => (
+          <Label
+            key={id}
+            onClose={() => onClose(id)}
+            onEditCancel={(_e, prevText) => onEdit(prevText, id)}
+            onEditComplete={(_e, newText) => onEdit(newText, id)}
+            isEditable
+            icon={!valid ? <InfoCircleIcon /> : null}
+            color={!valid ? 'red' : null}
+          >
+            {key + (value ? ': ' + value : '')}
+          </Label>
+        ))
+      ) : (
+        <>{t`None`}</>
+      )}
+    </LabelGroup>
+  ) : (
     <LabelGroup>
-      {Object.entries(labels).map(([k, v]) => (
-        <Label key={k}>
-          {k}
-          {v ? ': ' + v : null}
-        </Label>
-      ))}
+      {labelS.length ? (
+        labelS.map(({ key, value, id }) => (
+          <Label key={id}>
+            {key}
+            {value ? ': ' + value : null}
+          </Label>
+        ))
+      ) : (
+        <>{t`None`}</>
+      )}
     </LabelGroup>
   );
 };


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/0b961a5c-9a73-4442-a4be-8889a8ba38c4)

Add some logic to edit pulp-labels when creating/editing a repository. Just click on the label to edit them or hit the x/+ to remove/add them.

![image](https://github.com/user-attachments/assets/af254d05-fa80-47bf-bf89-ff9c59e3c2e4)
