### PR TITLE
Update paths, make beta a route property

### DIFF
--- a/src/app-routes.tsx
+++ b/src/app-routes.tsx
@@ -1,7 +1,7 @@
-import { t } from '@lingui/macro';
+import { Trans } from '@lingui/macro';
 import { Banner, Flex, FlexItem } from '@patternfly/react-core';
 import WrenchIcon from '@patternfly/react-icons/dist/esm/icons/wrench-icon';
-import React, { Component, type ElementType } from 'react';
+import React, { type ElementType } from 'react';
 import { Navigate, Route, Routes, useLocation } from 'react-router-dom';
 import { ExternalLink, NotFound } from 'src/components';
 import {
@@ -55,23 +55,251 @@ import { config } from 'src/ui-config';
 import { loginURL } from 'src/utilities';
 import { useUserContext } from './user-context';
 
-interface IAuthHandlerProps {
+interface IRouteConfig {
+  beta?: boolean;
   component: ElementType;
-  noAuth: boolean;
+  noAuth?: boolean;
   path: string;
 }
 
-interface IRouteConfig {
-  component: ElementType;
-  path: string;
-  noAuth?: boolean;
-}
+const routes: IRouteConfig[] = [
+  {
+    component: ExecutionEnvironmentDetailActivities,
+    path: Paths.container.repository.activities,
+    beta: true,
+  },
+  {
+    component: ExecutionEnvironmentDetailAccess,
+    path: Paths.container.repository.access,
+    beta: true,
+  },
+  {
+    component: ExecutionEnvironmentManifest,
+    path: Paths.container.repository.manifest,
+    beta: true,
+  },
+  {
+    component: ExecutionEnvironmentDetailImages,
+    path: Paths.container.repository.images,
+    beta: true,
+  },
+  {
+    component: ExecutionEnvironmentDetail,
+    path: Paths.container.repository.detail,
+    beta: true,
+  },
+  {
+    component: ExecutionEnvironmentList,
+    path: Paths.container.repository.list,
+    beta: true,
+  },
+  {
+    component: ExecutionEnvironmentRegistryList,
+    path: Paths.container.remote.list,
+    beta: true,
+  },
+  {
+    component: TaskListView,
+    path: Paths.core.task.list,
+  },
+  {
+    component: GroupList,
+    path: Paths.core.group.list,
+    beta: true,
+  },
+  {
+    component: GroupDetail,
+    path: Paths.core.group.detail,
+    beta: true,
+  },
+  {
+    component: TaskDetail,
+    path: Paths.core.task.detail,
+  },
+  {
+    component: EditRole,
+    path: Paths.core.role.edit,
+    beta: true,
+  },
+  {
+    component: RoleCreate,
+    path: Paths.core.role.create,
+    beta: true,
+  },
+  {
+    component: RoleList,
+    path: Paths.core.role.list,
+    beta: true,
+  },
+  {
+    component: AnsibleRemoteDetail,
+    path: Paths.ansible.remote.detail,
+    beta: true,
+  },
+  {
+    component: AnsibleRemoteEdit,
+    path: Paths.ansible.remote.edit,
+    beta: true,
+  },
+  {
+    component: AnsibleRemoteList,
+    path: Paths.ansible.remote.list,
+    beta: true,
+  },
+  {
+    component: AnsibleRepositoryDetail,
+    path: Paths.ansible.repository.detail,
+    beta: true,
+  },
+  {
+    component: AnsibleRepositoryEdit,
+    path: Paths.ansible.repository.edit,
+    beta: true,
+  },
+  {
+    component: AnsibleRepositoryList,
+    path: Paths.ansible.repository.list,
+    beta: true,
+  },
+  {
+    component: UserProfile,
+    path: Paths.core.user.profile,
+    beta: true,
+  },
+  {
+    component: UserCreate,
+    path: Paths.core.user.create,
+    beta: true,
+  },
+  {
+    component: SignatureKeysList,
+    path: Paths.core.signature_keys,
+  },
+  {
+    component: EditUser,
+    path: Paths.core.user.edit,
+    beta: true,
+  },
+  {
+    component: UserDetail,
+    path: Paths.core.user.detail,
+    beta: true,
+  },
+  {
+    component: UserList,
+    path: Paths.core.user.list,
+    beta: true,
+  },
+  {
+    component: Approvals,
+    path: Paths.ansible.approvals,
+    beta: true,
+  },
+  {
+    component: Partners,
+    path: Paths.ansible.namespace.list,
+    beta: true,
+  },
+  {
+    component: EditNamespace,
+    path: Paths.ansible.namespace.edit,
+    beta: true,
+  },
+  {
+    component: MyNamespaces,
+    path: Paths.ansible.namespace.mine,
+    beta: true,
+  },
+  {
+    component: LoginPage,
+    path: Paths.meta.login,
+    noAuth: true,
+    beta: true,
+  },
+  {
+    component: CollectionDocs,
+    path: Paths.ansible.collection.docs_page,
+    beta: true,
+  },
+  {
+    component: CollectionDocs,
+    path: Paths.ansible.collection.docs_index,
+    beta: true,
+  },
+  {
+    component: CollectionDocs,
+    path: Paths.ansible.collection.content_docs,
+    beta: true,
+  },
+  {
+    component: CollectionContent,
+    path: Paths.ansible.collection.content_list,
+    beta: true,
+  },
+  {
+    component: CollectionImportLog,
+    path: Paths.ansible.collection.imports,
+    beta: true,
+  },
+  {
+    component: CollectionDistributions,
+    path: Paths.ansible.collection.distributions,
+    beta: true,
+  },
+  {
+    component: CollectionDependencies,
+    path: Paths.ansible.collection.dependencies,
+    beta: true,
+  },
+  {
+    component: CollectionDetail,
+    path: Paths.ansible.collection.detail,
+    beta: true,
+  },
+  {
+    component: Search,
+    path: Paths.ansible.collection.list,
+    beta: true,
+  },
+  {
+    component: MyImports,
+    path: Paths.ansible.imports,
+    beta: true,
+  },
+  {
+    component: NamespaceDetail,
+    path: Paths.ansible.namespace.detail,
+    beta: true,
+  },
+  {
+    component: PulpStatus,
+    path: Paths.core.status,
+    noAuth: true,
+    beta: true,
+  },
+  {
+    component: MultiSearch,
+    path: Paths.meta.search,
+    beta: true,
+  },
+  {
+    component: AboutProject,
+    path: Paths.meta.about,
+    noAuth: true,
+  },
+  {
+    component: RPMPackageList,
+    path: Paths.rpm.package.list,
+    beta: true,
+  },
+];
 
 const AuthHandler = ({
+  beta,
   component: Component,
   noAuth,
   path,
-}: IAuthHandlerProps) => {
+}: IRouteConfig) => {
   const { credentials } = useUserContext();
   const { pathname } = useLocation();
 
@@ -87,164 +315,54 @@ const AuthHandler = ({
     );
   }
 
+  const banner = beta ? (
+    <Banner variant='blue'>
+      <Flex spaceItems={{ default: 'spaceItemsSm' }}>
+        <FlexItem>
+          <WrenchIcon />
+        </FlexItem>
+        <FlexItem>
+          <Trans>
+            This page is under construction and some features may be broken. You
+            can contribute at{' '}
+            <ExternalLink href='https://github.com/pulp/pulp-ui'>
+              Pulp UI
+            </ExternalLink>
+            .
+          </Trans>
+        </FlexItem>
+      </Flex>
+    </Banner>
+  ) : null;
+
   return (
     <>
-      {![
-        Paths.core.task.list,
-        Paths.core.task.detail,
-        Paths.meta.about,
-        Paths.core.signature_keys,
-      ].includes(path) && (
-        <Banner variant='blue'>
-          <Flex spaceItems={{ default: 'spaceItemsSm' }}>
-            <FlexItem>
-              <WrenchIcon />
-            </FlexItem>
-            <FlexItem>
-              {t`This page is under construction and some features may be broken. You can contribute at `}{' '}
-              <ExternalLink href={'https://github.com/pulp/pulp-ui'}>
-                Pulp UI{' '}
-              </ExternalLink>{' '}
-            </FlexItem>
-          </Flex>
-        </Banner>
-      )}
+      {banner}
       <Component path={path} />
     </>
   );
 };
 
-export class AppRoutes extends Component {
-  // Note: must be ordered from most specific to least specific
-  getRoutes(): IRouteConfig[] {
-    return [
-      {
-        component: ExecutionEnvironmentDetailActivities,
-        path: Paths.container.repository.activities,
-      },
-      {
-        component: ExecutionEnvironmentDetailAccess,
-        path: Paths.container.repository.access,
-      },
-      {
-        component: ExecutionEnvironmentManifest,
-        path: Paths.container.repository.manifest,
-      },
-      {
-        component: ExecutionEnvironmentDetailImages,
-        path: Paths.container.repository.images,
-      },
-      {
-        component: ExecutionEnvironmentDetail,
-        path: Paths.container.repository.detail,
-      },
-      {
-        component: ExecutionEnvironmentList,
-        path: Paths.container.repository.list,
-      },
-      {
-        component: ExecutionEnvironmentRegistryList,
-        path: Paths.container.remote.list,
-      },
-      {
-        component: TaskListView,
-        path: Paths.core.task.list,
-      },
-      { component: GroupList, path: Paths.core.group.list },
-      { component: GroupDetail, path: Paths.core.group.detail },
-      { component: TaskDetail, path: Paths.core.task.detail },
-      { component: EditRole, path: Paths.core.role.edit },
-      {
-        component: RoleCreate,
-        path: Paths.core.role.create,
-      },
-      { component: RoleList, path: Paths.core.role.list },
-      { component: AnsibleRemoteDetail, path: Paths.ansible.remote.detail },
-      { component: AnsibleRemoteEdit, path: Paths.ansible.remote.edit },
-      { component: AnsibleRemoteList, path: Paths.ansible.remote.list },
-      {
-        component: AnsibleRepositoryDetail,
-        path: Paths.ansible.repository.detail,
-      },
-      {
-        component: AnsibleRepositoryEdit,
-        path: Paths.ansible.repository.edit,
-      },
-      { component: AnsibleRepositoryList, path: Paths.ansible.repository.list },
-      { component: UserProfile, path: Paths.core.user.profile },
-      {
-        component: UserCreate,
-        path: Paths.core.user.create,
-      },
-      { component: SignatureKeysList, path: Paths.core.signature_keys },
-      {
-        component: EditUser,
-        path: Paths.core.user.edit,
-      },
-      { component: UserDetail, path: Paths.core.user.detail },
-      { component: UserList, path: Paths.core.user.list },
-      { component: Approvals, path: Paths.ansible.approvals },
-      { component: Partners, path: Paths.ansible.namespace.list },
-      { component: EditNamespace, path: Paths.ansible.namespace.edit },
-      { component: MyNamespaces, path: Paths.ansible.namespace.mine },
-      { component: LoginPage, path: Paths.meta.login, noAuth: true },
-      {
-        component: CollectionDocs,
-        path: Paths.ansible.collection.docs_page,
-      },
-      {
-        component: CollectionDocs,
-        path: Paths.ansible.collection.docs_index,
-      },
-      {
-        component: CollectionDocs,
-        path: Paths.ansible.collection.content_docs,
-      },
-      {
-        component: CollectionContent,
-        path: Paths.ansible.collection.content_list,
-      },
-      {
-        component: CollectionImportLog,
-        path: Paths.ansible.collection.imports,
-      },
-      {
-        component: CollectionDistributions,
-        path: Paths.ansible.collection.distributions,
-      },
-      {
-        component: CollectionDependencies,
-        path: Paths.ansible.collection.dependencies,
-      },
-      { component: CollectionDetail, path: Paths.ansible.collection.detail },
-      { component: Search, path: Paths.ansible.collection.list },
-      { component: MyImports, path: Paths.ansible.imports },
-      { component: NamespaceDetail, path: Paths.ansible.namespace.detail },
-      { component: PulpStatus, path: Paths.core.status, noAuth: true },
-      { component: MultiSearch, path: Paths.meta.search },
-      { component: AboutProject, path: Paths.meta.about, noAuth: true },
-      { component: RPMPackageList, path: Paths.rpm.package.list },
-    ];
-  }
-
-  render() {
-    return (
-      <Routes>
-        {this.getRoutes().map(({ component, noAuth, path }, index) => (
-          <Route
-            element={
-              <AuthHandler component={component} noAuth={noAuth} path={path} />
-            }
-            key={index}
+export const AppRoutes = () => (
+  <Routes>
+    {routes.map(({ beta, component, noAuth, path }, index) => (
+      <Route
+        element={
+          <AuthHandler
+            beta={beta}
+            component={component}
+            noAuth={noAuth}
             path={path}
           />
-        ))}
-        <Route
-          path={'/'}
-          element={<Navigate to={formatPath(Paths.core.status)} />}
-        />
-        <Route path='*' element={<NotFound />} />
-      </Routes>
-    );
-  }
-}
+        }
+        key={index}
+        path={path}
+      />
+    ))}
+    <Route
+      path={'/'}
+      element={<Navigate to={formatPath(Paths.core.status)} />}
+    />
+    <Route path='*' element={<NotFound />} />
+  </Routes>
+);

--- a/src/components/orphan-cleanup-task-modal.tsx
+++ b/src/components/orphan-cleanup-task-modal.tsx
@@ -7,7 +7,7 @@ import {
   NumberInput,
 } from '@patternfly/react-core';
 import React from 'react';
-import { FormFieldHelper } from 'src/components/form-field-helper';
+import { DateComponent, FormFieldHelper } from 'src/components';
 
 interface IProps {
   cancelAction: () => void;
@@ -50,7 +50,7 @@ export const OrphanCleanupTaskModal = (props: IProps) => {
               });
             }}
             onChange={(event) => {
-              // @ts-expect-error:Property 'value' does not exist on type 'EventTarget'.
+              // @ts-expect-error: Property 'value' does not exist on type 'EventTarget'.
               const value = Number(event.target.value);
               if (value < 0 || Number.isNaN(value)) {
                 updateTask({
@@ -69,6 +69,18 @@ export const OrphanCleanupTaskModal = (props: IProps) => {
               });
             }}
           />
+          {taskValue.orphan_protection_time ? (
+            <>
+              {' '}
+              (
+              <DateComponent
+                date={new Date(
+                  Date.now() - taskValue.orphan_protection_time * 60 * 1000,
+                ).toISOString()}
+              />
+              )
+            </>
+          ) : null}
           <FormFieldHelper>
             {t`The value is in minutes. Usually the default is a day (1440). If set to zero it will clean all orphans.`}
           </FormFieldHelper>

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -52,72 +52,86 @@ export function formatEEPath(path, data, params?) {
 
 export const Paths = {
   ansible: {
-    approvals: '/approvals',
+    approvals: '/ansible/approvals',
     collection: {
       content_docs:
-        '/ansible/collections/:repo/:namespace/:collection/content/:type/:name',
-      content_list: '/ansible/collections/:repo/:namespace/:collection/content',
+        '/ansible/collections/content_docs/:repo/:namespace/:collection/:type/:name',
+      content_list: '/ansible/collections/content/:repo/:namespace/:collection',
       dependencies:
-        '/ansible/collections/:repo/:namespace/:collection/dependencies',
-      detail: '/ansible/collections/:repo/:namespace/:collection',
+        '/ansible/collections/dependencies/:repo/:namespace/:collection',
+      detail: '/ansible/collections/detail/:repo/:namespace/:collection',
       distributions:
-        '/ansible/collections/:repo/:namespace/:collection/distributions',
-      docs_index: '/ansible/collections/:repo/:namespace/:collection/docs',
-      docs_page: '/ansible/collections/:repo/:namespace/:collection/docs/:page',
-      imports: '/ansible/collections/:repo/:namespace/:collection/import-log',
+        '/ansible/collections/distributions/:repo/:namespace/:collection',
+      docs_index:
+        '/ansible/collections/docs_index/:repo/:namespace/:collection',
+      docs_page:
+        '/ansible/collections/docs_page/:repo/:namespace/:collection/:page',
+      imports: '/ansible/collections/imports/:repo/:namespace/:collection',
       list: '/ansible/collections',
     },
-    imports: '/my-imports',
+    imports: '/ansible/my-imports',
     namespace: {
-      detail: '/ansible/namespaces/:namespace',
-      edit: '/my-namespaces/edit/:namespace',
+      detail: '/ansible/namespaces/detail/:namespace',
+      edit: '/ansible/namespaces/edit/:namespace',
       list: '/ansible/namespaces',
       mine: '/ansible/my-namespaces',
     },
     remote: {
-      detail: '/ansible/remotes/:name',
-      edit: '/ansible/remotes/:name/edit',
+      detail: '/ansible/remotes/detail/:name',
+      edit: '/ansible/remotes/edit/:name',
       list: '/ansible/remotes',
     },
     repository: {
-      detail: '/ansible/repositories/:name',
-      edit: '/ansible/repositories/:name/edit',
+      detail: '/ansible/repositories/detail/:name',
+      edit: '/ansible/repositories/edit/:name',
       list: '/ansible/repositories',
     },
   },
   container: {
-    remote: { list: '/registries' },
+    remote: { list: '/container/remotes' },
     repository: {
-      access: '/containers/:namespace?/:container/_content/access',
-      activities: '/containers/:namespace?/:container/_content/activity',
-      detail: '/containers/:namespace?/:container',
-      images: '/containers/:namespace?/:container/_content/images',
-      list: '/containers',
-      manifest: '/containers/:namespace?/:container/_content/images/:digest',
+      access: '/container/containers/access/:namespace?/:container',
+      activities: '/container/containers/activity/:namespace?/:container',
+      detail: '/container/containers/detail/:namespace?/:container',
+      images: '/container/containers/images/:namespace?/:container',
+      list: '/container/containers',
+      manifest: '/container/containers/manifest/:namespace?/:container/:digest',
     },
   },
   core: {
     group: {
-      detail: '/group/:group',
-      list: '/group-list',
+      detail: '/groups/detail/:group',
+      list: '/groups',
     },
     role: {
       create: '/roles/create',
-      edit: '/role/:role',
+      edit: '/roles/edit/:role',
       list: '/roles',
     },
     signature_keys: '/signature-keys',
     status: '/status',
     task: {
-      detail: '/task/:task',
+      detail: '/tasks/detail/:task',
       list: '/tasks',
     },
     user: {
       create: '/users/create',
-      detail: '/users/:user_id',
-      edit: '/users/:user_id/edit',
+      detail: '/users/detail/:user_id',
+      edit: '/users/edit/:user_id',
       list: '/users',
-      profile: '/settings/user-profile',
+      profile: '/users/profile',
+    },
+  },
+  file: {
+    remote: {
+      detail: '/file/remotes/detail/:name',
+      edit: '/file/remotes/edit/:name',
+      list: '/file/remotes',
+    },
+    repository: {
+      detail: '/file/repositories/detail/:name',
+      edit: '/file/repositories/edit/:name',
+      list: '/file/repositories',
     },
   },
   meta: {


### PR DESCRIPTION
(pulling out things from #137)

Paths - update actual route paths to follow something like `/plugin/thing/screen/:ids` - prevent name clashes when a valid `/:name` is also a valid route candidate, make current tab name go before any ids.

Routes - pull out routes into a list, add beta as a param instead of whitelisting.

Task detail - make sure to only keep one polling interval, clear on change.

Orphan - add DateComponent to show a rough conversion from minutes