### PR TITLE
ReactFragment deprecated in React 19, replace with ReactNode

### DIFF
--- a/src/containers/execution-environment-detail/execution-environment-detail-activities.tsx
+++ b/src/containers/execution-environment-detail/execution-environment-detail-activities.tsx
@@ -2,7 +2,7 @@ import { t } from '@lingui/core/macro';
 import { Trans } from '@lingui/react/macro';
 import { Button, Flex, FlexItem } from '@patternfly/react-core';
 import { Table, Tbody, Td, Tr } from '@patternfly/react-table';
-import { Component, type ReactFragment } from 'react';
+import { Component, type ReactNode } from 'react';
 import { Link } from 'react-router';
 import { ActivitiesAPI } from 'src/api';
 import {
@@ -19,7 +19,7 @@ import './execution-environment-detail.scss';
 
 interface IState {
   loading: boolean;
-  activities: { created: string; action: ReactFragment }[];
+  activities: { created: string; action: ReactNode }[];
   redirect: string;
   page: number;
 }


### PR DESCRIPTION
`ReactFragment` (type) is deprecated, but `ReactNode` makes sense there anyway, replacing

---

TODO(eventually): Actually switch to react 19

https://react.dev/blog/2024/12/05/react-19
https://react.dev/blog/2024/04/25/react-19-upgrade-guide

(looks like it works fine, but:

* patternfly wants `^17 || ^18` [(here)](https://github.com/patternfly/patternfly-react/blob/main/packages/react-core/package.json#L63-L64)
* typescript really doesn't like class component `state`/`setState` now
* typescript forgot about `"jsx": "react-jsx"`?

)

waiting with that, only merging the prep fix now