### PR TITLE
workflows/stale: Add workflow to close stale issues and PRs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,23 @@
+name: 'Close stale issues and PRs'
+on:
+  schedule:
+    - cron: '4 4 * * 4'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # only for delete-branch option
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v9
+        with:
+          days-before-issue-stale: 384
+          days-before-pr-stale: 192
+          days-before-close: 32
+          stale-issue-label: 'stale'
+          stale-pr-label: 'stale'
+          exempt-issue-labels: 'pinned'
+          exempt-pr-labels: 'pinned'
+          delete-branch: true


### PR DESCRIPTION
Add a workflow to close stale issues and PRs:
* runs on Thursdays
* adds a `stale` label after 384 days of inactivity on an issue, or 192 on a PR
* closes a `stale` issue/PR after 32 extra days of inactivity
* ignores `pinned` issues/PRs

[actions/stale](https://github.com/actions/stale?tab=readme-ov-file); [labels](https://github.com/pulp/pulp-ui/labels)