### PR TITLE
GroupList, GroupDetail - fix deletion alert [object Object]

### DIFF
--- a/src/components/list-page.tsx
+++ b/src/components/list-page.tsx
@@ -185,15 +185,15 @@ export const ListPage = function <T>({
     }
 
     componentDidMount() {
+      this.setState({ alerts: (this.context as IAppContextType).alerts || [] });
+      (this.context as IAppContextType).setAlerts([]);
+
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       if (condition && !condition(this.context as any)) {
         this.setState({ loading: false, unauthorized: true });
       } else {
         this.query();
       }
-
-      this.setState({ alerts: (this.context as IAppContextType).alerts || [] });
-      (this.context as IAppContextType).setAlerts([]);
     }
 
     render() {

--- a/src/components/page-with-tabs.tsx
+++ b/src/components/page-with-tabs.tsx
@@ -109,15 +109,15 @@ export const PageWithTabs = function <
     }
 
     componentDidMount() {
+      this.setState({ alerts: (this.context as IAppContextType).alerts || [] });
+      (this.context as IAppContextType).setAlerts([]);
+
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       if (condition && !condition(this.context as any)) {
         this.setState({ loading: false, unauthorized: true });
       } else {
         this.query();
       }
-
-      this.setState({ alerts: (this.context as IAppContextType).alerts || [] });
-      (this.context as IAppContextType).setAlerts([]);
     }
 
     componentDidUpdate(prevProps) {

--- a/src/components/page.tsx
+++ b/src/components/page.tsx
@@ -90,6 +90,9 @@ export const Page = function <
     }
 
     componentDidMount() {
+      this.setState({ alerts: (this.context as IAppContextType).alerts || [] });
+      (this.context as IAppContextType).setAlerts([]);
+
       // condition check after query, for object permissions
       this.query().then((item) => {
         const actionContext = {
@@ -97,15 +100,11 @@ export const Page = function <
           hasObjectPermission: (permission) =>
             item?.my_permissions?.includes?.(permission),
         };
+
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         if (condition && !condition(actionContext as any)) {
           this.setState({ loading: false, unauthorized: true });
         }
-
-        this.setState({
-          alerts: (this.context as IAppContextType).alerts || [],
-        });
-        (this.context as IAppContextType).setAlerts([]);
       });
     }
 

--- a/src/containers/execution-environment-list/execution-environment-list.tsx
+++ b/src/containers/execution-environment-list/execution-environment-list.tsx
@@ -110,12 +110,10 @@ class ExecutionEnvironmentList extends Component<RouteProps, IState> {
   }
 
   componentDidMount() {
-    this.queryEnvironments();
-    this.setState({ alerts: (this.context as IAppContextType).alerts });
-  }
-
-  componentWillUnmount() {
+    this.setState({ alerts: (this.context as IAppContextType).alerts || [] });
     (this.context as IAppContextType).setAlerts([]);
+
+    this.queryEnvironments();
   }
 
   render() {

--- a/src/containers/group-management/group-detail.tsx
+++ b/src/containers/group-management/group-detail.tsx
@@ -409,6 +409,7 @@ class GroupDetail extends Component<RouteProps, IState> {
 
   private renderGroupDeleteModal() {
     const { group, users, itemCount } = this.state;
+    const { hasPermission, queueAlert } = this.context as IAppContextType;
 
     const deleteAction = () => {
       GroupAPI.delete(group.id)
@@ -416,22 +417,22 @@ class GroupDetail extends Component<RouteProps, IState> {
           this.setState({
             showDeleteModal: false,
           });
-          this.addAlert(
-            t`Group "${group}" has been successfully deleted.`,
-            'success',
-          );
+          queueAlert({
+            title: t`Group "${group.name}" has been successfully deleted.`,
+            variant: 'success',
+          });
           this.setState({ redirect: formatPath(Paths.core.group.list) });
         })
         .catch((e) => {
           const { status, statusText } = e.response;
           this.addAlert(
-            t`Group "${group}" could not be deleted.`,
+            t`Group "${group.name}" could not be deleted.`,
             'danger',
             jsxErrorMessage(status, statusText),
           );
         });
     };
-    const { hasPermission } = this.context as IAppContextType;
+
     const view_user = hasPermission('galaxy.view_user');
 
     if (!users && view_user) {

--- a/src/containers/group-management/group-list.tsx
+++ b/src/containers/group-management/group-list.tsx
@@ -103,6 +103,9 @@ class GroupList extends Component<RouteProps, IState> {
   }
 
   componentDidMount() {
+    this.setState({ alerts: (this.context as IAppContextType).alerts || [] });
+    (this.context as IAppContextType).setAlerts([]);
+
     const { hasPermission } = this.context as IAppContextType;
     if (!hasPermission('galaxy.view_group')) {
       this.setState({ unauthorized: true });
@@ -363,7 +366,7 @@ class GroupList extends Component<RouteProps, IState> {
             ...this.state.alerts,
             {
               variant: 'danger',
-              title: t`Changes to group "${this.state.selectedGroup}" could not be saved.`,
+              title: t`Changes to group "${this.state.selectedGroup.name}" could not be saved.`,
             },
           ],
         }),

--- a/src/containers/namespace-detail/namespace-detail.tsx
+++ b/src/containers/namespace-detail/namespace-detail.tsx
@@ -146,10 +146,10 @@ export class NamespaceDetail extends Component<RouteProps, IState> {
   }
 
   componentDidMount() {
-    this.load();
-
     this.setState({ alerts: (this.context as IAppContextType).alerts || [] });
     (this.context as IAppContextType).setAlerts([]);
+
+    this.load();
   }
 
   componentDidUpdate(prevProps) {


### PR DESCRIPTION
When deleting a group, fix deletion alert "[object Object]" - and also that it was invisible because alert+redirect.
Change to `queueAlert`, change `group` to `group.name`, add `GroupList` "move alerts from context to state" logic.
And update it everywhere to run *before* the query function.

Should fix the type errors in #224