### PR TITLE
pulp-login: change roles/ to groups/

### DIFF
--- a/src/api/pulp-login.ts
+++ b/src/api/pulp-login.ts
@@ -4,6 +4,9 @@ const base = new PulpAPI();
 
 export const PulpLoginAPI = {
   try: (username, password) =>
-    // roles = any api that will always be there and requires auth
-    base.http.get(`roles/`, { auth: { username, password } }),
+    // groups = any api that will always be there and requires auth
+    base.http.get(`groups/`, {
+      auth: { username, password },
+      params: { limit: 0, offset: 0 },
+    }),
 };


### PR DESCRIPTION
Closes #198

We still need an api endpoint to check whether we're logged in or not (until #183)
but `/pulp/api/v3/roles/` requires the user to be admin.

Changing to `/pulp/api/v3/groups/`, as per #198.