### PR TITLE
Added run_container.sh script, formatted README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,4 @@ cypress/videos/*
 dist/
 node_modules/
 npm-debug.log*
-tests/settings
+tests/settings/certs/

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ cypress/videos/*
 dist/
 node_modules/
 npm-debug.log*
+tests/settings

--- a/README.md
+++ b/README.md
@@ -6,14 +6,32 @@ A community driven UI for [Pulp](https://pulpproject.org/).
 
 ### Backend
 
-The `tests/run_container.sh` script is provided and allows you to run a command with a [Pulp in one](https://pulpproject.org/pulp-in-one-container/) container active.
-It requires Docker or Podman to be installed.
-The default credentials are:
-Username: admin
-Password: password
+You can follow the [pulp-oci-images quickstart](https://pulpproject.org/pulp-oci-images/docs/admin/tutorials/quickstart/),
+TLDR:
 
+#### Setup:
+
+```sh
+mkdir -p ~/pulp-backend-oci/{settings/certs,pulp_storage,pgsql,containers}
+cd ~/pulp-backend-oci/
+echo "
+CONTENT_ORIGIN='http://$(hostname):8080'
+ANSIBLE_API_HOSTNAME='http://$(hostname):8080'
+ANSIBLE_CONTENT_HOSTNAME='http://$(hostname):8080/pulp/content'
+" >> settings/settings.py
 ```
-./tests/run_container sleep inf
+
+#### Run:
+
+```sh
+cd ~/pulp-backend-oci/
+podman run --publish 8080:80 \
+           --replace --name pulp \
+           --volume "$(pwd)/settings":/etc/pulp \
+           --volume "$(pwd)/pulp_storage":/var/lib/pulp \
+           --volume "$(pwd)/pgsql":/var/lib/pgsql \
+           --volume "$(pwd)/containers":/var/lib/containers \
+           docker.io/pulp/pulp
 ```
 
 #### Check:
@@ -33,6 +51,24 @@ pulp config create --username admin --base-url http://localhost:8080 --password 
 pulp --help
 pulp user list
 ```
+
+### Setup (run_container.sh script)
+
+The `tests/run_container.sh` script is provided and allows you to run a command with a [Pulp OCI-image](https://pulpproject.org/pulp-oci-images/docs/admin/tutorials/quickstart/) container running.
+
+It requires Docker or Podman to be installed.
+
+The default credentials are:
+ * Username: admin
+ * Password: password
+
+```
+./tests/run_container sleep inf
+```
+
+The following optional environment variable is availble to be set:
+
+* `IMAGE_TAG`: Change the Pulp OCI image tage to use, defaults to `latest`
 
 ### Frontend
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,15 @@ curl localhost:8080/pulp/api/v3/status/ | jq
 
 or open http://localhost:8080/pulp/api/v3/status/
 
+#### Change password:
+
+```sh
+podman exec -it pulp pulpcore-manager reset-admin-password --password admin
+```
+```sh
+docker exec -it compose-pulp_api-1 pulpcore-manager reset-admin-password --password admin
+```
+
 #### Configure `pulp-cli`:
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -4,37 +4,19 @@ A community driven UI for [Pulp](https://pulpproject.org/).
 
 ## How to run
 
-### backend
+### Backend
 
-You can follow the [pulp-oci-images quickstart](https://pulpproject.org/pulp-oci-images/docs/admin/tutorials/quickstart/),
-TLDR:
+The `tests/run_container.sh` script is provided and allows you to run a command with a [Pulp in one](https://pulpproject.org/pulp-in-one-container/) container active.
+It requires Docker or Podman to be installed.
+The default credentials are:
+Username: admin
+Password: password
 
-#### setup:
-
-```sh
-mkdir -p ~/pulp-backend-oci/{settings/certs,pulp_storage,pgsql,containers}
-cd ~/pulp-backend-oci/
-echo "
-CONTENT_ORIGIN='http://$(hostname):8080'
-ANSIBLE_API_HOSTNAME='http://$(hostname):8080'
-ANSIBLE_CONTENT_HOSTNAME='http://$(hostname):8080/pulp/content'
-" >> settings/settings.py
+```
+./tests/run_container sleep inf
 ```
 
-#### run:
-
-```sh
-cd ~/pulp-backend-oci/
-podman run --publish 8080:80 \
-           --replace --name pulp \
-           --volume "$(pwd)/settings":/etc/pulp \
-           --volume "$(pwd)/pulp_storage":/var/lib/pulp \
-           --volume "$(pwd)/pgsql":/var/lib/pgsql \
-           --volume "$(pwd)/containers":/var/lib/containers \
-           docker.io/pulp/pulp
-```
-
-#### check:
+#### Check:
 
 ```sh
 curl localhost:8080/pulp/api/v3/status/ | jq
@@ -42,26 +24,17 @@ curl localhost:8080/pulp/api/v3/status/ | jq
 
 or open http://localhost:8080/pulp/api/v3/status/
 
-#### change password:
-
-```sh
-podman exec -it pulp pulpcore-manager reset-admin-password --password admin
-```
-```sh
-docker exec -it compose-pulp_api-1 pulpcore-manager reset-admin-password --password admin
-```
-
-#### configure `pulp-cli`:
+#### Configure `pulp-cli`:
 
 ```sh
 pip install pulp-cli[pygments]
-pulp config create --username admin --base-url http://localhost:8080 --password admin
+pulp config create --username admin --base-url http://localhost:8080 --password password
 
 pulp --help
 pulp user list
 ```
 
-### frontend
+### Frontend
 
 You can clone the frontend from https://github.com/pulp/pulp-ui .
 
@@ -72,12 +45,12 @@ npm run start
 
 and open http://localhost:8002/ :tada: :)
 
-If your API listens elsewhere, you can use `API_PROXY=http://elsewhere:12345 npm run start` instead. Do note that the server at `elsewhere` has to be configured to allow CORS requests for `localhost` (where UI actually listens); using something like `changeOrigin` is out of scope for pulp-ui, and breaks pulp API URLs (because the domains are based on the Origin header). Do NOT use webpack proxy in production.
+If your PULP API listens elsewhere, you can use `API_PROXY=http://elsewhere:12345 npm run start` instead. Do note that the server at `elsewhere` has to be configured to allow CORS requests for `localhost` (where UI actually listens); using something like `changeOrigin` is out of scope for pulp-ui, and breaks pulp API URLs (because the domains are based on the Origin header). Do NOT use webpack proxy in production.
 
 
 ## Misc
 
-### post-build configuration
+### Post-build configuration
 
 The UI builds produced by `npm run build` can be further configured by serving a `/pulp-ui-config.json` alongside the built UI.
 (Note it has to be mapped at `/`, not just wherever `index.html` is served from.)

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ docker exec -it compose-pulp_api-1 pulpcore-manager reset-admin-password --passw
 
 ```sh
 pip install pulp-cli[pygments]
-pulp config create --username admin --base-url http://localhost:8080 --password password
+pulp config create --username admin --base-url http://localhost:8080 --password admin
 
 pulp --help
 pulp user list
@@ -69,7 +69,7 @@ It requires Docker or Podman to be installed.
 
 The default credentials are:
  * Username: admin
- * Password: password
+ * Password: admin
 
 ```
 ./tests/run_container sleep inf

--- a/tests/run_container.sh
+++ b/tests/run_container.sh
@@ -48,7 +48,7 @@ fi
   --volume "${BASEPATH}/settings:/etc/pulp${SELINUX:+:Z}" \
   --publish "8080:80" \
   --network "bridge" \
-  "ghcr.io/pulp/pulp:${IMAGE_TAG}"
+  "docker.io/pulp/pulp:${IMAGE_TAG}"
 
 # shellcheck disable=SC2064
 trap "${CONTAINER_RUNTIME} stop pulp-ephemeral" EXIT

--- a/tests/run_container.sh
+++ b/tests/run_container.sh
@@ -1,0 +1,97 @@
+#!/bin/sh
+
+# This file is shared between some projects please keep all copies in sync
+# Known places:
+#   - https://github.com/pulp/pulp-cli/blob/main/.ci/run_container.sh
+#   - https://github.com/pulp/pulp-cli-deb/blob/main/.ci/run_container.sh
+#   - https://github.com/pulp/pulp-cli-ostree/blob/main/.ci/run_container.sh
+#   - https://github.com/pulp/squeezer/blob/develop/tests/run_container.sh
+#   - https://github.com/pulp/pulp-ui/blob/main/tests/run_container.sh
+
+set -eu
+
+BASEPATH="$(dirname "$(readlink -f "$0")")"
+export BASEPATH
+
+if [ -z "${CONTAINER_RUNTIME:+x}" ]
+then
+  if ls /usr/bin/podman
+  then
+    CONTAINER_RUNTIME=podman
+  else
+    CONTAINER_RUNTIME=docker
+  fi
+fi
+export CONTAINER_RUNTIME
+
+if [ -z "${KEEP_CONTAINER:+x}" ]
+then
+  RM="yes"
+else
+  RM=""
+fi
+
+IMAGE_TAG="${IMAGE_TAG:-latest}"
+FROM_TAG="${FROM_TAG:-latest}"
+
+if [ "${CONTAINER_FILE:+x}" ]
+then
+  IMAGE_TAG="ephemeral-build"
+  "${CONTAINER_RUNTIME}" build --file "${BASEPATH}/assets/${CONTAINER_FILE}" --build-arg FROM_TAG="${FROM_TAG}" --tag ghcr.io/pulp/pulp:"${IMAGE_TAG}" .
+fi
+
+if [ "$(getenforce)" = "Enforcing" ]; then
+    SELINUX="yes"
+else
+    SELINUX=""
+fi;
+
+"${CONTAINER_RUNTIME}" \
+  run ${RM:+--rm} \
+  --env S6_KEEP_ENV=1 \
+  ${PULP_API_ROOT:+--env PULP_API_ROOT} \
+  --detach \
+  --name "pulp-ephemeral" \
+  --volume "${BASEPATH}/settings:/etc/pulp${SELINUX:+:Z}" \
+  --publish "8080:80" \
+  --network "bridge" \
+  "ghcr.io/pulp/pulp:${IMAGE_TAG}"
+
+# shellcheck disable=SC2064
+trap "${CONTAINER_RUNTIME} stop pulp-ephemeral" EXIT
+# shellcheck disable=SC2064
+trap "${CONTAINER_RUNTIME} stop pulp-ephemeral" INT
+
+echo "Wait for pulp to start."
+for counter in $(seq 40 -1 0)
+do
+  if [ "$counter" = "0" ]
+  then
+    echo "FAIL."
+    "${CONTAINER_RUNTIME}" images
+    "${CONTAINER_RUNTIME}" ps -a
+    "${CONTAINER_RUNTIME}" logs "pulp-ephemeral"
+    exit 1
+  fi
+
+  sleep 3
+  if curl --fail "http://localhost:8080${PULP_API_ROOT:-/pulp/}api/v3/status/" > /dev/null 2>&1
+  then
+    echo "SUCCESS."
+    break
+  fi
+  echo "."
+done
+
+# show pulpcore/plugin versions we're using
+curl -s "http://localhost:8080${PULP_API_ROOT:-/pulp/}api/v3/status/" | jq '.versions|map({key: .component, value: .version})|from_entries'
+
+# Set admin password
+"${CONTAINER_RUNTIME}" exec "pulp-ephemeral" pulpcore-manager reset-admin-password --password password
+
+if [ -d "${BASEPATH}/container_setup.d/" ]
+then
+  run-parts --regex '^[0-9]+-[-_[:alnum:]]*\.sh$' "${BASEPATH}/container_setup.d/"
+fi
+
+PULP_LOGGING="${CONTAINER_RUNTIME}" "$@"

--- a/tests/run_container.sh
+++ b/tests/run_container.sh
@@ -80,6 +80,6 @@ done
 curl -s "http://localhost:8080/pulp/api/v3/status/" | jq '.versions|map({key: .component, value: .version})|from_entries'
 
 # Set admin password
-"${CONTAINER_RUNTIME}" exec "pulp-ephemeral" pulpcore-manager reset-admin-password --password password
+"${CONTAINER_RUNTIME}" exec "pulp-ephemeral" pulpcore-manager reset-admin-password --password admin
 
 PULP_LOGGING="${CONTAINER_RUNTIME}" "$@"

--- a/tests/settings/settings.py
+++ b/tests/settings/settings.py
@@ -1,0 +1,5 @@
+CONTENT_ORIGIN = "http://localhost:8080/"
+ALLOWED_EXPORT_PATHS = ["/tmp"]
+CACHE_ENABLED = True
+REDIS_HOST = "localhost"
+REDIS_PORT = 6379


### PR DESCRIPTION
This commit adds the `tests/run_container.sh` script from: https://github.com/pulp/squeezer/blob/develop/tests/run_container.sh

It provides an easy way to start a pulp oci container. 