### PR TITLE
feat(containers): add native sidebar and detail tabs support

### DIFF
--- a/src/api/container-remote-native.ts
+++ b/src/api/container-remote-native.ts
@@ -1,0 +1,23 @@
+import { PulpAPI } from './pulp';
+
+const base = new PulpAPI();
+
+export interface ContainerRemoteNativeType {
+  pulp_href: string;
+  name: string;
+  url: string;
+  pulp_created: string;
+  pulp_last_updated: string;
+  policy: string;
+  tls_validation: boolean;
+  proxy_url: string | null;
+  ca_cert: string | null;
+  client_cert: string | null;
+  hidden_fields: { name: string; is_set: boolean }[];
+}
+
+export const ContainerRemoteNativeAPI = {
+  get: (id: string) => base.http.get(`remotes/container/container/${id}/`),
+
+  list: (params?) => base.list('remotes/container/container/', params),
+};

--- a/src/api/container-repository-native.ts
+++ b/src/api/container-repository-native.ts
@@ -1,0 +1,46 @@
+import { PulpAPI } from './pulp';
+import { config } from 'src/ui-config';
+
+const base = new PulpAPI();
+
+const toRelativeHref = (href: string) =>
+  href?.replace(config.API_BASE_PATH, '') || href;
+
+export interface ContainerRepositoryNativeType {
+  pulp_href: string;
+  name: string;
+  description: string | null;
+  remote: string | null;
+  pulp_created: string;
+  pulp_last_updated: string;
+  latest_version_href?: string;
+  retain_repo_versions?: number;
+  pulp_labels?: Record<string, string>;
+}
+
+export interface ContainerRepositoryVersionType {
+  pulp_href: string;
+  pulp_created: string;
+  number: number;
+  repository: string;
+  base_version: string | null;
+  content_summary: {
+    added: Record<string, { count: number; href: string }>;
+    removed: Record<string, { count: number; href: string }>;
+    present: Record<string, { count: number; href: string }>;
+  };
+}
+
+export const ContainerRepositoryNativeAPI = {
+  get: (id: string) => base.http.get(`repositories/container/container/${id}/`),
+
+  getByHref: (href: string) => base.http.get(toRelativeHref(href)),
+
+  list: (params?) => base.list('repositories/container/container/', params),
+
+  listVersions: (id: string, params?) =>
+    base.list(`repositories/container/container/${id}/versions/`, params),
+
+  listVersionsByHref: (href: string, params?) =>
+    base.list(`${toRelativeHref(href)}versions/`, params),
+};

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -12,6 +12,15 @@ export {
   ContainerDistributionAPI,
   ContainerPullThroughDistributionAPI,
 } from './container-distribution';
+export {
+  ContainerRepositoryNativeAPI,
+  type ContainerRepositoryNativeType,
+  type ContainerRepositoryVersionType,
+} from './container-repository-native';
+export {
+  ContainerRemoteNativeAPI,
+  type ContainerRemoteNativeType,
+} from './container-remote-native';
 export { ContainerTagAPI } from './container-tag';
 export { ExecutionEnvironmentAPI } from './execution-environment';
 export { ExecutionEnvironmentNamespaceAPI } from './execution-environment-namespace';

--- a/src/components/container-repository-sidebar.tsx
+++ b/src/components/container-repository-sidebar.tsx
@@ -1,0 +1,168 @@
+import { t } from '@lingui/core/macro';
+import {
+  Nav,
+  NavExpandable,
+  NavItem,
+  Title,
+} from '@patternfly/react-core';
+import { useEffect, useMemo, useState } from 'react';
+import { Link } from 'react-router';
+import {
+  ContainerDistributionAPI,
+} from 'src/api';
+import { EmptyStateNoData } from 'src/components';
+import { Paths, formatEEPath } from 'src/paths';
+import { NavList, SearchInput, Spinner } from './patternfly-wrappers/l10n';
+
+interface NativeContainerDistributionType {
+  name: string;
+  base_path: string;
+  remote: string | null;
+  description: string | null;
+  pulp_created: string;
+}
+
+type RepositoryTypeGroup = 'local' | 'remote';
+
+interface IProps {
+  selectedRepository?: string;
+}
+
+const PAGE_SIZE = 200;
+
+const repositoryType = (
+  repository: NativeContainerDistributionType,
+): RepositoryTypeGroup =>
+  repository.remote ? 'remote' : 'local';
+
+async function loadAllRepositories() {
+  const result = await ContainerDistributionAPI.list({
+    page_size: PAGE_SIZE,
+    sort: 'name',
+  });
+  return result.data.results as NativeContainerDistributionType[];
+}
+
+export const ContainerRepositorySidebar = ({ selectedRepository }: IProps) => {
+  const [filter, setFilter] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [repositories, setRepositories] = useState<NativeContainerDistributionType[]>([]);
+  const [error, setError] = useState<string>(null);
+  const typeLabels: Record<RepositoryTypeGroup, string> = {
+    local: t`Local`,
+    remote: t`Remote`,
+  };
+
+  useEffect(() => {
+    let cancelled = false;
+
+    loadAllRepositories()
+      .then((items) => {
+        if (!cancelled) {
+          setRepositories(items);
+          setLoading(false);
+        }
+      })
+      .catch((e) => {
+        if (!cancelled) {
+          setError(e?.message || t`Failed to load repositories.`);
+          setLoading(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const groupedRepositories = useMemo(() => {
+    const normalizedFilter = filter.toLowerCase();
+    const filtered = repositories.filter(({ name, base_path }) => {
+      const haystack = [name, base_path]
+        .filter(Boolean)
+        .join('/')
+        .toLowerCase();
+
+      return haystack.includes(normalizedFilter);
+    });
+
+    return {
+      local: filtered.filter((repository) => repositoryType(repository) === 'local'),
+      remote: filtered.filter((repository) => repositoryType(repository) === 'remote'),
+    };
+  }, [filter, repositories]);
+
+  const hasResults = Object.values(groupedRepositories).some(
+    ({ length }) => length > 0,
+  );
+
+  return (
+    <aside className='container-repository-sidebar'>
+      <div className='container-repository-sidebar__header'>
+        <Title headingLevel='h2' size='lg'>
+          {t`Repository types`}
+        </Title>
+        <SearchInput
+          value={filter}
+          onChange={(_event, value) => setFilter(value)}
+          onClear={() => setFilter('')}
+          aria-label={t`Filter repositories`}
+          placeholder={t`Filter repositories`}
+        />
+      </div>
+
+      {loading ? (
+        <div className='container-repository-sidebar__status'>
+          <Spinner size='md' />
+        </div>
+      ) : error ? (
+        <EmptyStateNoData
+          title={t`Repositories unavailable`}
+          description={error}
+        />
+      ) : !hasResults ? (
+        <EmptyStateNoData
+          title={t`No matching repositories`}
+          description={
+            filter
+              ? t`No repositories match the current filter.`
+              : t`No repositories are available.`
+          }
+        />
+      ) : (
+        <Nav theme='light' aria-label={t`Container repositories by type`}>
+          <NavList>
+            {(['local', 'remote'] as RepositoryTypeGroup[])
+              .filter((type) => groupedRepositories[type].length > 0)
+              .map((type) => (
+                <NavExpandable
+                  key={type}
+                  title={`${typeLabels[type]} (${groupedRepositories[type].length})`}
+                  isExpanded
+                >
+                  {groupedRepositories[type].map((repository) => {
+                    const link = formatEEPath(Paths.container.repository.detail, {
+                      container: repository.base_path,
+                    });
+
+                    return (
+                      <NavItem
+                        key={repository.name}
+                        isActive={selectedRepository === repository.name}
+                      >
+                        <Link to={link}>
+                          <span className='container-repository-sidebar__link'>
+                            {repository.name}
+                          </span>
+                        </Link>
+                      </NavItem>
+                    );
+                  })}
+                </NavExpandable>
+              ))}
+          </NavList>
+        </Nav>
+      )}
+    </aside>
+  );
+};

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -19,6 +19,7 @@ export { CollectionUsedbyDependenciesList } from './collection-usedby-dependenci
 export { CompoundFilter, type FilterOption } from './compound-filter';
 export { ConfirmModal } from './confirm-modal';
 export { ContainerRepositoryForm } from './container-repository-form';
+export { ContainerRepositorySidebar } from './container-repository-sidebar';
 export { CopyCollectionToRepositoryModal } from './copy-collection-to-repository-modal';
 export { CopyURL } from './copy-url';
 export { DarkmodeSwitcher } from './darkmode-switcher';

--- a/src/containers/execution-environment-detail/execution-environment-detail-native.tsx
+++ b/src/containers/execution-environment-detail/execution-environment-detail-native.tsx
@@ -1,0 +1,335 @@
+import { t } from '@lingui/core/macro';
+import { Component } from 'react';
+import {
+  ContainerDistributionAPI,
+  ContainerRemoteNativeAPI,
+  ContainerRepositoryNativeAPI,
+  type ContainerRepositoryNativeType,
+  type ContainerRemoteNativeType,
+} from 'src/api';
+import { AppContext, type IAppContextType } from 'src/app-context';
+import {
+  AlertList,
+  type AlertType,
+  BaseHeader,
+  Breadcrumbs,
+  LinkTabs,
+  LoadingSpinner,
+  Main,
+  NotFound,
+  closeAlert,
+} from 'src/components';
+import { Paths, formatEEPath, formatPath } from 'src/paths';
+import {
+  ParamHelper,
+  parsePulpIDFromURL,
+  type RouteProps,
+  withRouter,
+} from 'src/utilities';
+import { DetailsTab } from './tab-details';
+import { DistributionsTab } from './tab-distributions';
+import { RepositoryVersionsTab } from './tab-repository-versions';
+
+interface ContainerDistributionType {
+  pulp_href: string;
+  pulp_created: string;
+  pulp_last_updated: string;
+  name: string;
+  description: string | null;
+  base_path: string;
+  registry_path: string;
+  repository: string | null;
+  remote: string | null;
+}
+
+export interface ContainerDetailItem
+  extends Omit<ContainerDistributionType, 'repository' | 'remote'> {
+  repositoryHref?: string | null;
+  remoteHref?: string | null;
+  repository?: ContainerRepositoryNativeType | null;
+  remote?: ContainerRemoteNativeType | null;
+}
+
+export interface ContainerDetailTabProps {
+  item: ContainerDetailItem;
+  actionContext: {
+    addAlert: (alert: AlertType) => void;
+    state: { params: Record<string, string> };
+    hasPermission: (permission: string) => boolean;
+    hasObjectPermission: (permission: string) => boolean;
+  };
+}
+
+interface IState {
+  alerts: AlertType[];
+  item: ContainerDetailItem | null;
+  loading: boolean;
+  notFound: boolean;
+  params: Record<string, string>;
+}
+
+const containerName = ({
+  namespace,
+  container,
+}: Record<string, string>): string =>
+  [namespace, container].filter(Boolean).join('/');
+
+class ExecutionEnvironmentDetail extends Component<RouteProps, IState> {
+  static contextType = AppContext;
+
+  constructor(props) {
+    super(props);
+
+    const params = ParamHelper.parseParamString(props.location.search) as Record<
+      string,
+      string
+    >;
+
+    if (!params.tab) {
+      params.tab = 'details';
+    }
+
+    this.state = {
+      alerts: [],
+      item: null,
+      loading: true,
+      notFound: false,
+      params,
+    };
+  }
+
+  componentDidMount() {
+    this.setState({ alerts: (this.context as IAppContextType).alerts || [] });
+    (this.context as IAppContextType).setAlerts([]);
+
+    this.load();
+  }
+
+  componentDidUpdate(prevProps) {
+    const oldContainer = containerName(prevProps.routeParams);
+    const newContainer = containerName(this.props.routeParams);
+
+    if (oldContainer !== newContainer) {
+      this.load();
+      return;
+    }
+
+    if (prevProps.location.search !== this.props.location.search) {
+      const params = ParamHelper.parseParamString(
+        this.props.location.search,
+      ) as Record<string, string>;
+      this.setState({ params: { tab: 'details', ...params } });
+    }
+  }
+
+  render() {
+    const { alerts, item, loading, notFound, params } = this.state;
+
+    if (notFound) {
+      return (
+        <>
+          <AlertList
+            alerts={alerts}
+            closeAlert={(index) =>
+              closeAlert(index, {
+                alerts,
+                setAlerts: (next) => this.setState({ alerts: next }),
+              })
+            }
+          />
+          <NotFound />
+        </>
+      );
+    }
+
+    const tab = params.tab || 'details';
+    const title = item?.name || containerName(this.props.routeParams);
+
+    return (
+      <>
+        <AlertList
+          alerts={alerts}
+          closeAlert={(index) =>
+            closeAlert(index, {
+              alerts,
+              setAlerts: (next) => this.setState({ alerts: next }),
+            })
+          }
+        />
+        <BaseHeader
+          title={title}
+          breadcrumbs={
+            <Breadcrumbs
+              links={this.breadcrumbs(item, tab, this.state.params)}
+            />
+          }
+        >
+          {item && (
+            <div className='pulp-tab-link-container'>
+              <div className='tabs'>{this.renderTabs(tab, item)}</div>
+            </div>
+          )}
+        </BaseHeader>
+        <Main>
+          {loading ? (
+            <LoadingSpinner />
+          ) : (
+            <section className='pulp-section'>
+              {item && this.renderTab(tab, item)}
+            </section>
+          )}
+        </Main>
+      </>
+    );
+  }
+
+  private breadcrumbs(item: ContainerDetailItem | null, tab: string, params) {
+    const basePath = item?.base_path || containerName(this.props.routeParams);
+
+    return [
+      { url: formatPath(Paths.container.repository.list), name: t`Containers` },
+      {
+        url: formatEEPath(Paths.container.repository.detail, {
+          container: basePath,
+        }),
+        name: item?.name || basePath,
+      },
+      tab === 'repository-versions' && params.repositoryVersion
+        ? {
+            url: formatEEPath(
+              Paths.container.repository.detail,
+              { container: basePath },
+              { tab: 'repository-versions' },
+            ),
+            name: t`Versions`,
+          }
+        : null,
+      tab === 'repository-versions' && params.repositoryVersion
+        ? { name: t`Version ${params.repositoryVersion}` }
+        : null,
+      tab === 'repository-versions' && !params.repositoryVersion
+        ? { name: t`Versions` }
+        : null,
+      tab === 'distributions' ? { name: t`Distributions` } : null,
+      tab === 'details' ? { name: t`Details` } : null,
+    ].filter(Boolean);
+  }
+
+  private renderTabs(tab: string, item: ContainerDetailItem) {
+    return (
+      <LinkTabs
+        tabs={[
+          {
+            active: tab === 'details',
+            title: t`Details`,
+            link: formatEEPath(
+              Paths.container.repository.detail,
+              { container: item.base_path },
+              { tab: 'details' },
+            ),
+          },
+          {
+            active: tab === 'repository-versions',
+            title: t`Versions`,
+            link: formatEEPath(
+              Paths.container.repository.detail,
+              { container: item.base_path },
+              { tab: 'repository-versions' },
+            ),
+          },
+          {
+            active: tab === 'distributions',
+            title: t`Distributions`,
+            link: formatEEPath(
+              Paths.container.repository.detail,
+              { container: item.base_path },
+              { tab: 'distributions' },
+            ),
+          },
+        ]}
+      />
+    );
+  }
+
+  private renderTab(tab: string, item: ContainerDetailItem) {
+    const actionContext = {
+      addAlert: (alert: AlertType) => this.addAlert(alert),
+      state: { params: this.state.params },
+      hasPermission: (this.context as IAppContextType).hasPermission,
+      hasObjectPermission: (_permission: string) => true,
+    };
+
+    return (
+      {
+        details: <DetailsTab item={item} actionContext={actionContext} />,
+        'repository-versions': (
+          <RepositoryVersionsTab item={item} actionContext={actionContext} />
+        ),
+        distributions: (
+          <DistributionsTab item={item} actionContext={actionContext} />
+        ),
+      }[tab] || <DetailsTab item={item} actionContext={actionContext} />
+    );
+  }
+
+  private load() {
+    const basePath = containerName(this.props.routeParams);
+
+    this.setState({ loading: true, notFound: false }, () => {
+      ContainerDistributionAPI.list({ base_path: basePath, page_size: 1 })
+        .then(({ data }) => {
+          const distribution = data?.results?.[0] as ContainerDistributionType;
+
+          if (!distribution) {
+            throw new Error('not-found');
+          }
+
+          const repositoryPromise = distribution.repository
+            ? ContainerRepositoryNativeAPI.getByHref(distribution.repository)
+                .then((result) => result.data as ContainerRepositoryNativeType)
+                .catch(() => null)
+            : Promise.resolve(null);
+
+          return Promise.all([Promise.resolve(distribution), repositoryPromise]);
+        })
+        .then(([distribution, repository]) => {
+          const remoteHref = repository?.remote || distribution.remote;
+          const remotePromise = remoteHref
+            ? ContainerRemoteNativeAPI.get(parsePulpIDFromURL(remoteHref))
+                .then((result) => result.data as ContainerRemoteNativeType)
+                .catch(() => null)
+            : Promise.resolve(null);
+
+          return Promise.all([
+            Promise.resolve(distribution),
+            Promise.resolve(repository),
+            remotePromise,
+          ]);
+        })
+        .then(([distribution, repository, remote]) => {
+          this.setState({
+            item: {
+              ...distribution,
+              repositoryHref: distribution.repository,
+              remoteHref: distribution.remote,
+              repository,
+              remote,
+              name: repository?.name || distribution.name || distribution.base_path,
+              description: repository?.description || distribution.description,
+            },
+            loading: false,
+            notFound: false,
+          });
+        })
+        .catch(() => {
+          this.setState({ loading: false, notFound: true, item: null });
+        });
+    });
+  }
+
+  private addAlert(alert: AlertType) {
+    this.setState({ alerts: [...this.state.alerts, alert] });
+  }
+}
+
+export default withRouter(ExecutionEnvironmentDetail);

--- a/src/containers/execution-environment-detail/tab-details.tsx
+++ b/src/containers/execution-environment-detail/tab-details.tsx
@@ -1,0 +1,56 @@
+import { t } from '@lingui/core/macro';
+import { Link } from 'react-router';
+import { DateComponent, Details, PulpLabels } from 'src/components';
+import { Paths, formatPath } from 'src/paths';
+import { type ContainerDetailTabProps } from './execution-environment-detail-native';
+
+export const DetailsTab = ({ item }: ContainerDetailTabProps) => {
+  const remote = item.remote;
+
+  return (
+    <Details
+      fields={[
+        { label: t`Repo name`, value: item.repository?.name || item.name },
+        { label: t`Description`, value: item.repository?.description || t`None` },
+        { label: t`Base path`, value: item.base_path },
+        { label: t`Registry path`, value: item.registry_path || t`None` },
+        {
+          label: t`Created`,
+          value: <DateComponent date={item.repository?.pulp_created || item.pulp_created} />,
+        },
+        {
+          label: t`Last modified`,
+          value: (
+            <DateComponent
+              date={item.repository?.pulp_last_updated || item.pulp_last_updated}
+            />
+          ),
+        },
+        {
+          label: t`Labels`,
+          value: <PulpLabels labels={item.repository?.pulp_labels || {}} />,
+        },
+        {
+          label: t`Remotes`,
+          value: remote ? (
+            <Link
+              to={formatPath(
+                Paths.container.remote.list,
+                {},
+                { name__icontains: remote.name },
+              )}
+            >
+              {remote.name}
+            </Link>
+          ) : (
+            t`None`
+          ),
+        },
+        {
+          label: t`Remote URL`,
+          value: remote?.url || t`None`,
+        },
+      ]}
+    />
+  );
+};

--- a/src/containers/execution-environment-detail/tab-distributions.tsx
+++ b/src/containers/execution-environment-detail/tab-distributions.tsx
@@ -1,0 +1,109 @@
+import { t } from '@lingui/core/macro';
+import { Td, Tr } from '@patternfly/react-table';
+import { ContainerDistributionAPI } from 'src/api';
+import { ClipboardCopy, DateComponent, DetailList } from 'src/components';
+import { getContainersURL } from 'src/utilities';
+import { type ContainerDetailTabProps } from './execution-environment-detail-native';
+
+interface DistributionType {
+  pulp_href: string;
+  pulp_created: string;
+  name: string;
+  base_path: string;
+  registry_path: string;
+  repository: string | null;
+  remote: string | null;
+}
+
+export const DistributionsTab = ({
+  item,
+  actionContext: { addAlert, hasPermission },
+}: ContainerDetailTabProps) => {
+  const query = ({ params } = { params: null }) => {
+    const newParams = { ...params };
+    newParams.ordering = newParams.sort;
+    delete newParams.sort;
+
+    const relationFilter = item.repository?.pulp_href
+      ? { repository: item.repository.pulp_href }
+      : { base_path: item.base_path };
+
+    return ContainerDistributionAPI.list({
+      ...relationFilter,
+      ...newParams,
+    });
+  };
+
+  const cliConfig = (basePath: string) =>
+    `podman pull ${getContainersURL({ name: basePath, tag: 'latest' })}`;
+
+  const renderTableRow = (distribution: DistributionType, index: number) => {
+    const { name, base_path, pulp_created } = distribution;
+
+    return (
+      <Tr key={index}>
+        <Td>{name}</Td>
+        <Td>{base_path}</Td>
+        <Td>
+          <DateComponent date={pulp_created} />
+        </Td>
+        <Td>
+          <ClipboardCopy isCode isReadOnly variant='inline-compact' key={index}>
+            {cliConfig(base_path)}
+          </ClipboardCopy>
+        </Td>
+      </Tr>
+    );
+  };
+
+  return (
+    <DetailList<DistributionType>
+      actionContext={{
+        addAlert,
+        query,
+        hasPermission,
+        hasObjectPermission: (_permission: string): boolean => true,
+      }}
+      defaultPageSize={10}
+      defaultSort='name'
+      errorTitle={t`Distributions could not be displayed.`}
+      filterConfig={[
+        {
+          id: 'name__icontains',
+          title: t`Name`,
+        },
+        {
+          id: 'base_path__icontains',
+          title: t`Base path`,
+        },
+      ]}
+      noDataDescription={t`No distributions found for this container repository.`}
+      noDataTitle={t`No distributions yet`}
+      query={query}
+      renderTableRow={renderTableRow}
+      sortHeaders={[
+        {
+          title: t`Name`,
+          type: 'alpha',
+          id: 'name',
+        },
+        {
+          title: t`Base path`,
+          type: 'alpha',
+          id: 'base_path',
+        },
+        {
+          title: t`Created`,
+          type: 'alpha',
+          id: 'pulp_created',
+        },
+        {
+          title: t`CLI configuration`,
+          type: 'none',
+          id: '',
+        },
+      ]}
+      title={t`Distributions`}
+    />
+  );
+};

--- a/src/containers/execution-environment-detail/tab-repository-versions.tsx
+++ b/src/containers/execution-environment-detail/tab-repository-versions.tsx
@@ -1,0 +1,331 @@
+import { t } from '@lingui/core/macro';
+import { Table, Td, Th, Tr } from '@patternfly/react-table';
+import { useEffect, useState } from 'react';
+import { Link } from 'react-router';
+import {
+  GenericPulpAPI,
+  ContainerRepositoryNativeAPI,
+  type ContainerRepositoryVersionType,
+} from 'src/api';
+import {
+  ClipboardCopy,
+  DateComponent,
+  DetailList,
+  Details,
+  EmptyStateNoData,
+  ListItemActions,
+  Spinner,
+} from 'src/components';
+import { Paths, formatEEPath } from 'src/paths';
+import { getContainersURL } from 'src/utilities';
+import { type ContainerDetailTabProps } from './execution-environment-detail-native';
+
+const ContentSummary = ({ data }: { data: object }) => {
+  if (!Object.keys(data).length) {
+    return <>{t`None`}</>;
+  }
+
+  return (
+    <Table>
+      <Tr>
+        <Th>{t`Count`}</Th>
+        <Th>{t`Pulp type`}</Th>
+      </Tr>
+      {Object.entries(data).map(([key, value]) => (
+        <Tr key={key}>
+          <Td>{value['count']}</Td>
+          <Th>{key}</Th>
+        </Tr>
+      ))}
+    </Table>
+  );
+};
+
+const BaseVersion = ({
+  basePath,
+  data,
+}: {
+  basePath: string;
+  data?: string;
+}) => {
+  if (!data) {
+    return <>{t`None`}</>;
+  }
+
+  const number = data.split('/').at(-2);
+  return (
+    <Link
+      to={formatEEPath(
+        Paths.container.repository.detail,
+        {
+          container: basePath,
+        },
+        {
+          repositoryVersion: number,
+          tab: 'repository-versions',
+        },
+      )}
+    >
+      {number}
+    </Link>
+  );
+};
+
+interface ContainerTagType {
+  name: string;
+  tagged_manifest: string;
+}
+
+interface ContainerManifestType {
+  pulp_href: string;
+  digest: string;
+}
+
+interface PullReference {
+  tag: string;
+  digest?: string;
+}
+
+const PullReferences = ({
+  refs,
+  basePath,
+  loading,
+}: {
+  refs: PullReference[];
+  basePath: string;
+  loading: boolean;
+}) => {
+  if (loading) {
+    return <Spinner size='sm' />;
+  }
+
+  if (!refs.length) {
+    return <>{t`None`}</>;
+  }
+
+  return (
+    <div style={{ display: 'grid', gap: '8px' }}>
+      {refs.map((ref) => (
+        <div key={`${ref.tag}-${ref.digest || 'no-digest'}`}>
+          <div style={{ marginBottom: '4px' }}>
+            <strong>{ref.tag}</strong>
+          </div>
+          <ClipboardCopy isCode isReadOnly variant='inline-compact'>
+            {getContainersURL({ name: basePath, tag: ref.tag })}
+          </ClipboardCopy>
+          {ref.digest ? (
+            <div style={{ marginTop: '4px' }}>
+              <ClipboardCopy isCode isReadOnly variant='inline-compact'>
+                {getContainersURL({ name: basePath, digest: ref.digest })}
+              </ClipboardCopy>
+            </div>
+          ) : null}
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export const RepositoryVersionsTab = ({
+  item,
+  actionContext: { addAlert, state, hasPermission, hasObjectPermission },
+}: ContainerDetailTabProps) => {
+  const repository = item.repository;
+
+  if (!repository) {
+    return (
+      <EmptyStateNoData
+        title={t`No repository versions yet`}
+        description={t`This container does not have an associated repository version history.`}
+      />
+    );
+  }
+
+  const latestHref = repository.latest_version_href;
+  const basePath = item.base_path;
+  const queryList = ({ params }) =>
+    ContainerRepositoryNativeAPI.listVersionsByHref(repository.pulp_href, params);
+  const queryDetail = ({ number }) =>
+    ContainerRepositoryNativeAPI.listVersionsByHref(repository.pulp_href, {
+      number,
+    });
+  const [modalState, setModalState] = useState({});
+  const [version, setVersion] = useState<ContainerRepositoryVersionType | null>(
+    null,
+  );
+  const [pullReferences, setPullReferences] = useState<PullReference[]>([]);
+  const [pullReferencesLoading, setPullReferencesLoading] = useState(false);
+
+  useEffect(() => {
+    if (state.params.repositoryVersion) {
+      queryDetail({ number: state.params.repositoryVersion }).then(({ data }) => {
+        if (!data?.results?.[0]) {
+          addAlert({
+            variant: 'danger',
+            title: t`Failed to find repository version`,
+          });
+        }
+        setVersion(data.results[0]);
+      });
+    } else {
+      setVersion(null);
+    }
+  }, [state.params.repositoryVersion]);
+
+  useEffect(() => {
+    if (!version?.pulp_href) {
+      setPullReferences([]);
+      return;
+    }
+
+    setPullReferencesLoading(true);
+
+    Promise.all([
+      GenericPulpAPI.list('content/container/tags/', {
+        repository_version: version.pulp_href,
+        limit: 200,
+        offset: 0,
+      }),
+      GenericPulpAPI.list('content/container/manifests/', {
+        repository_version: version.pulp_href,
+        limit: 200,
+        offset: 0,
+      }),
+    ])
+      .then(([tagResult, manifestResult]) => {
+        const tags = (tagResult?.data?.results || []) as ContainerTagType[];
+        const manifests =
+          (manifestResult?.data?.results || []) as ContainerManifestType[];
+
+        const digestByManifestHref = new Map(
+          manifests.map((manifest) => [manifest.pulp_href, manifest.digest]),
+        );
+
+        setPullReferences(
+          tags.map((tag) => ({
+            tag: tag.name,
+            digest: digestByManifestHref.get(tag.tagged_manifest),
+          })),
+        );
+      })
+      .catch(() => setPullReferences([]))
+      .finally(() => setPullReferencesLoading(false));
+  }, [version?.pulp_href]);
+
+  const renderTableRow = (
+    versionItem: ContainerRepositoryVersionType,
+    index: number,
+    actionCtx,
+    listItemActions,
+  ) => {
+    const { number, pulp_created, pulp_href } = versionItem;
+
+    const isLatest = latestHref === pulp_href;
+
+    const kebabItems = listItemActions.map((action) =>
+      action.dropdownItem({ ...versionItem, isLatest }, actionCtx),
+    );
+
+    return (
+      <Tr key={index}>
+        <Td>
+          <Link
+            to={formatEEPath(
+              Paths.container.repository.detail,
+              {
+                container: basePath,
+              },
+              {
+                repositoryVersion: number,
+                tab: 'repository-versions',
+              },
+            )}
+          >
+            {number}
+          </Link>
+          {isLatest ? ' ' + t`(latest)` : null}
+        </Td>
+        <Td>
+          <DateComponent date={pulp_created} />
+        </Td>
+        <ListItemActions kebabItems={kebabItems} />
+      </Tr>
+    );
+  };
+
+  return state.params.repositoryVersion ? (
+    version ? (
+      <Details
+        fields={[
+          { label: t`Version number`, value: version.number },
+          {
+            label: t`Created date`,
+            value: <DateComponent date={version.pulp_created} />,
+          },
+          {
+            label: t`Content added`,
+            value: <ContentSummary data={version.content_summary?.added || {}} />,
+          },
+          {
+            label: t`Content removed`,
+            value: <ContentSummary data={version.content_summary?.removed || {}} />,
+          },
+          {
+            label: t`Current content`,
+            value: <ContentSummary data={version.content_summary?.present || {}} />,
+          },
+          {
+            label: t`Base version`,
+            value: <BaseVersion basePath={basePath} data={version.base_version} />,
+          },
+          {
+            label: t`Pull references`,
+            value: (
+              <PullReferences
+                refs={pullReferences}
+                basePath={basePath}
+                loading={pullReferencesLoading}
+              />
+            ),
+          },
+        ]}
+      />
+    ) : (
+      <Spinner size='md' />
+    )
+  ) : (
+    <DetailList<ContainerRepositoryVersionType>
+      actionContext={{
+        addAlert,
+        state: modalState,
+        setState: setModalState,
+        query: queryList,
+        hasPermission,
+        hasObjectPermission,
+      }}
+      defaultPageSize={10}
+      defaultSort='-pulp_created'
+      errorTitle={t`Repository versions could not be displayed.`}
+      filterConfig={null}
+      listItemActions={[]}
+      noDataButton={null}
+      noDataDescription={t`Repository versions will appear once the repository is modified.`}
+      noDataTitle={t`No repository versions yet`}
+      query={queryList}
+      renderTableRow={renderTableRow}
+      sortHeaders={[
+        {
+          title: t`Version number`,
+          type: 'numeric',
+          id: 'number',
+        },
+        {
+          title: t`Created date`,
+          type: 'numeric',
+          id: 'pulp_created',
+        },
+      ]}
+      title={t`Repository versions`}
+    />
+  );
+};

--- a/src/containers/execution-environment-list/execution-environment-list-native.tsx
+++ b/src/containers/execution-environment-list/execution-environment-list-native.tsx
@@ -1,0 +1,399 @@
+import { t } from '@lingui/core/macro';
+import {
+  Label,
+  Toolbar,
+  ToolbarContent,
+  ToolbarGroup,
+  ToolbarItem,
+} from '@patternfly/react-core';
+import { Table, Tbody, Td, Tr } from '@patternfly/react-table';
+import { Component } from 'react';
+import { Link } from 'react-router';
+import { ContainerDistributionAPI } from 'src/api';
+import { AppContext, type IAppContextType } from 'src/app-context';
+import {
+  AlertList,
+  type AlertType,
+  AppliedFilters,
+  BaseHeader,
+  ClipboardCopy,
+  CompoundFilter,
+  ContainerRepositorySidebar,
+  DateComponent,
+  DeleteExecutionEnvironmentModal,
+  EmptyStateFilter,
+  EmptyStateNoData,
+  ExternalLink,
+  HelpButton,
+  ListItemActions,
+  LoadingSpinner,
+  Main,
+  PulpPagination,
+  SortTable,
+  Tooltip,
+  closeAlert,
+} from 'src/components';
+import { Paths, formatEEPath } from 'src/paths';
+import {
+  ParamHelper,
+  type RouteProps,
+  filterIsSet,
+  getContainersURL,
+  withRouter,
+} from 'src/utilities';
+import './execution-environment.scss';
+
+interface ExecutionEnvironmentType {
+  pulp_created: string;
+  name: string;
+  description: string;
+  pulp_last_updated: string;
+  base_path: string;
+  remote: string | null;
+  registry_path: string;
+}
+
+interface IState {
+  alerts: AlertType[];
+  itemCount: number;
+  items: ExecutionEnvironmentType[];
+  loading: boolean;
+  params: {
+    page?: number;
+    page_size?: number;
+  };
+  showDeleteModal: boolean;
+  selectedItem: ExecutionEnvironmentType;
+  inputText: string;
+}
+
+class ExecutionEnvironmentList extends Component<RouteProps, IState> {
+  static contextType = AppContext;
+
+  constructor(props) {
+    super(props);
+
+    const params = ParamHelper.parseParamString(props.location.search, [
+      'page',
+      'page_size',
+    ]);
+
+    if (!params['page_size']) {
+      params['page_size'] = 10;
+    }
+
+    if (!params['sort']) {
+      params['sort'] = 'name';
+    }
+
+    this.state = {
+      alerts: [],
+      itemCount: 0,
+      items: [],
+      loading: true,
+      params,
+      showDeleteModal: false,
+      selectedItem: null,
+      inputText: '',
+    };
+  }
+
+  componentDidMount() {
+    this.setState({ alerts: (this.context as IAppContextType).alerts || [] });
+    (this.context as IAppContextType).setAlerts([]);
+
+    this.queryEnvironments();
+  }
+
+  render() {
+    const {
+      alerts,
+      itemCount,
+      items,
+      loading,
+      params,
+      showDeleteModal,
+      selectedItem,
+    } = this.state;
+
+    const noData =
+      items.length === 0 && !filterIsSet(params, ['name__icontains']);
+
+    const tlsVerify = window.location.protocol == 'https:';
+    const serverURL = getContainersURL({ name: '' }).replace(/\/$/, '');
+    const containerURL = getContainersURL({ name: 'example', tag: 'latest' });
+    const instructions = (
+      <ClipboardCopy isCode isReadOnly isExpanded variant='expansion'>
+        podman login --tls-verify={tlsVerify.toString()} {serverURL}
+        {'\n'}
+        podman image tag example {containerURL}
+        {'\n'}
+        podman push --tls-verify={tlsVerify.toString()} {containerURL}
+        {'\n'}
+      </ClipboardCopy>
+    );
+
+    const pushImagesButton = (
+      <HelpButton
+        content={
+          <>
+            {instructions}
+            <ExternalLink href='https://docs.pulpproject.org/'>{t`Documentation`}</ExternalLink>
+          </>
+        }
+        hasAutoWidth
+        header={t`Push container images`}
+        prefix={
+          <span data-cy='push-images-button'>{t`Push container images`}</span>
+        }
+      />
+    );
+
+    return (
+      <>
+        <AlertList
+          alerts={alerts}
+          closeAlert={(i) =>
+            closeAlert(i, {
+              alerts,
+              setAlerts: (alerts) => this.setState({ alerts }),
+            })
+          }
+        />
+        <BaseHeader title={t`Containers`} />
+
+        {showDeleteModal && (
+          <DeleteExecutionEnvironmentModal
+            selectedItem={selectedItem ? selectedItem.name : ''}
+            closeAction={() =>
+              this.setState({ showDeleteModal: false, selectedItem: null })
+            }
+            afterDelete={() => this.queryEnvironments()}
+            addAlert={(text, variant, description = undefined) =>
+              this.setState({
+                alerts: alerts.concat([
+                  { title: text, variant: variant, description: description },
+                ]),
+              })
+            }
+          />
+        )}
+        {noData && !loading ? (
+          <EmptyStateNoData
+            title={t`No container repositories yet`}
+            description={t`You currently have no container repositories. Add a container repository via the CLI to get started.`}
+            button={pushImagesButton}
+          />
+        ) : (
+          <Main>
+            {loading ? (
+              <LoadingSpinner />
+            ) : (
+              <section className='pulp-section execution-environment-layout'>
+                <ContainerRepositorySidebar />
+                <div className='execution-environment-layout__content'>
+                  <div className='pulp-toolbar'>
+                    <Toolbar>
+                      <ToolbarContent>
+                        <ToolbarGroup>
+                          <ToolbarItem>
+                            <CompoundFilter
+                              inputText={this.state.inputText}
+                              onChange={(text) =>
+                                this.setState({ inputText: text })
+                              }
+                              updateParams={(p) =>
+                                this.updateParams(p, () =>
+                                  this.queryEnvironments(),
+                                )
+                              }
+                              params={params}
+                              filterConfig={[
+                                {
+                                  id: 'name__icontains',
+                                  title: t`Container repository name`,
+                                },
+                              ]}
+                            />
+                          </ToolbarItem>
+                          <ToolbarItem>
+                            <div style={{ paddingTop: '6px' }}>
+                              {pushImagesButton}
+                            </div>
+                          </ToolbarItem>
+                        </ToolbarGroup>
+                      </ToolbarContent>
+                    </Toolbar>
+
+                    <PulpPagination
+                      params={params}
+                      updateParams={(p) =>
+                        this.updateParams(p, () => this.queryEnvironments())
+                      }
+                      count={itemCount}
+                      isTop
+                    />
+                  </div>
+                  <div>
+                    <AppliedFilters
+                      updateParams={(p) => {
+                        this.updateParams(p, () => this.queryEnvironments());
+                        this.setState({ inputText: '' });
+                      }}
+                      params={params}
+                      ignoredParams={['page_size', 'page', 'sort']}
+                      niceNames={{
+                        name__icontains: t`Name`,
+                      }}
+                    />
+                  </div>
+                  {this.renderTable(params)}
+
+                  <PulpPagination
+                    params={params}
+                    updateParams={(p) =>
+                      this.updateParams(p, () => this.queryEnvironments())
+                    }
+                    count={itemCount}
+                  />
+                </div>
+              </section>
+            )}
+          </Main>
+        )}
+      </>
+    );
+  }
+
+  private renderTable(params) {
+    const { items } = this.state;
+    if (items.length === 0) {
+      return <EmptyStateFilter />;
+    }
+
+    const sortTableOptions = {
+      headers: [
+        {
+          title: t`Container repository name`,
+          type: 'alpha',
+          id: 'name',
+        },
+        {
+          title: t`Description`,
+          type: 'alpha',
+          id: 'description',
+        },
+        {
+          title: t`Created`,
+          type: 'numeric',
+          id: 'created_at',
+        },
+        {
+          title: t`Last modified`,
+          type: 'alpha',
+          id: 'updated_at',
+        },
+        {
+          title: t`Container registry type`,
+          type: 'none',
+          id: 'type',
+        },
+        {
+          title: '',
+          type: 'none',
+          id: 'controls',
+        },
+      ],
+    };
+
+    return (
+      <Table>
+        <SortTable
+          options={sortTableOptions}
+          params={params}
+          updateParams={(p) =>
+            this.updateParams(p, () => this.queryEnvironments())
+          }
+        />
+        <Tbody>{items.map((user, i) => this.renderTableRow(user, i))}</Tbody>
+      </Table>
+    );
+  }
+
+  private renderTableRow(item, index: number) {
+    const description = item.description;
+
+    return (
+      <Tr data-cy={`ExecutionEnvironmentList-row-${item.name}`} key={index}>
+        <Td>
+          <Link
+            to={formatEEPath(Paths.container.repository.detail, {
+              container: item.base_path,
+            })}
+          >
+            {item.name}
+          </Link>
+        </Td>
+        {description ? (
+          <Td className={'pf-m-truncate'}>
+            <Tooltip content={description}>{description}</Tooltip>
+          </Td>
+        ) : (
+          <Td />
+        )}
+        <Td>
+          <DateComponent date={item.pulp_created} />
+        </Td>
+        <Td>
+          <DateComponent date={item.pulp_last_updated} />
+        </Td>
+        <Td>
+          <Label>{item.remote ? t`Remote` : t`Local`}</Label>
+        </Td>
+        <ListItemActions kebabItems={[]} />
+      </Tr>
+    );
+  }
+
+  private queryEnvironments() {
+    this.setState({ loading: true }, () =>
+      ContainerDistributionAPI.list(this.state.params)
+        .then((result) => {
+          this.setState({
+            items: result.data.results,
+            itemCount: result.data.count,
+            loading: false,
+          });
+        })
+        .catch((e) =>
+          this.addAlert(t`Error loading environments.`, 'danger', e?.message),
+        ),
+    );
+  }
+
+  private updateParams(params, callback = null) {
+    ParamHelper.updateParams({
+      params,
+      navigate: (to) => this.props.navigate(to),
+      setState: (state) => this.setState(state, callback),
+    });
+  }
+
+  private addAlert(title, variant, description?) {
+    this.addAlertObj({
+      description,
+      title,
+      variant,
+    });
+  }
+
+  private addAlertObj(alert) {
+    this.setState({
+      alerts: [...this.state.alerts, alert],
+    });
+  }
+
+
+}
+
+export default withRouter(ExecutionEnvironmentList);

--- a/src/containers/execution-environment-list/execution-environment-list-native.tsx
+++ b/src/containers/execution-environment-list/execution-environment-list-native.tsx
@@ -20,7 +20,6 @@ import {
   CompoundFilter,
   ContainerRepositorySidebar,
   DateComponent,
-  DeleteExecutionEnvironmentModal,
   EmptyStateFilter,
   EmptyStateNoData,
   ExternalLink,
@@ -62,8 +61,6 @@ interface IState {
     page?: number;
     page_size?: number;
   };
-  showDeleteModal: boolean;
-  selectedItem: ExecutionEnvironmentType;
   inputText: string;
 }
 
@@ -92,8 +89,6 @@ class ExecutionEnvironmentList extends Component<RouteProps, IState> {
       items: [],
       loading: true,
       params,
-      showDeleteModal: false,
-      selectedItem: null,
       inputText: '',
     };
   }
@@ -106,15 +101,7 @@ class ExecutionEnvironmentList extends Component<RouteProps, IState> {
   }
 
   render() {
-    const {
-      alerts,
-      itemCount,
-      items,
-      loading,
-      params,
-      showDeleteModal,
-      selectedItem,
-    } = this.state;
+    const { alerts, itemCount, items, loading, params } = this.state;
 
     const noData =
       items.length === 0 && !filterIsSet(params, ['name__icontains']);
@@ -162,22 +149,6 @@ class ExecutionEnvironmentList extends Component<RouteProps, IState> {
         />
         <BaseHeader title={t`Containers`} />
 
-        {showDeleteModal && (
-          <DeleteExecutionEnvironmentModal
-            selectedItem={selectedItem ? selectedItem.name : ''}
-            closeAction={() =>
-              this.setState({ showDeleteModal: false, selectedItem: null })
-            }
-            afterDelete={() => this.queryEnvironments()}
-            addAlert={(text, variant, description = undefined) =>
-              this.setState({
-                alerts: alerts.concat([
-                  { title: text, variant: variant, description: description },
-                ]),
-              })
-            }
-          />
-        )}
         {noData && !loading ? (
           <EmptyStateNoData
             title={t`No container repositories yet`}
@@ -350,7 +321,9 @@ class ExecutionEnvironmentList extends Component<RouteProps, IState> {
         <Td>
           <Label>{item.remote ? t`Remote` : t`Local`}</Label>
         </Td>
-        <ListItemActions kebabItems={[]} />
+        <Td isActionCell>
+          <ListItemActions kebabItems={[]} />
+        </Td>
       </Tr>
     );
   }
@@ -365,9 +338,10 @@ class ExecutionEnvironmentList extends Component<RouteProps, IState> {
             loading: false,
           });
         })
-        .catch((e) =>
-          this.addAlert(t`Error loading environments.`, 'danger', e?.message),
-        ),
+        .catch((e) => {
+          this.setState({ loading: false });
+          this.addAlert(t`Error loading environments.`, 'danger', e?.message);
+        }),
     );
   }
 
@@ -392,8 +366,6 @@ class ExecutionEnvironmentList extends Component<RouteProps, IState> {
       alerts: [...this.state.alerts, alert],
     });
   }
-
-
 }
 
 export default withRouter(ExecutionEnvironmentList);

--- a/src/containers/execution-environment-list/execution-environment.scss
+++ b/src/containers/execution-environment-list/execution-environment.scss
@@ -1,3 +1,50 @@
 .delete-container-modal-message {
   padding-bottom: var(--pf-v5-global--spacer--md);
 }
+
+.execution-environment-layout {
+  display: grid;
+  gap: var(--pf-v5-global--spacer--lg);
+  grid-template-columns: minmax(18rem, 22rem) minmax(0, 1fr);
+}
+
+.execution-environment-layout__content {
+  min-width: 0;
+}
+
+.container-repository-sidebar {
+  border: 1px solid var(--pf-v5-global--BorderColor--100);
+  border-radius: var(--pf-v5-global--BorderRadius--sm);
+  padding: var(--pf-v5-global--spacer--md);
+  position: sticky;
+  top: var(--pf-v5-global--spacer--lg);
+}
+
+.container-repository-sidebar__header {
+  display: grid;
+  gap: var(--pf-v5-global--spacer--sm);
+  margin-bottom: var(--pf-v5-global--spacer--md);
+}
+
+.container-repository-sidebar__status {
+  display: flex;
+  justify-content: center;
+  padding: var(--pf-v5-global--spacer--xl) 0;
+}
+
+.container-repository-sidebar__link {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+@media (max-width: 992px) {
+  .execution-environment-layout {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .container-repository-sidebar {
+    position: static;
+  }
+}

--- a/src/containers/execution-environment/registry-list-native.tsx
+++ b/src/containers/execution-environment/registry-list-native.tsx
@@ -1,0 +1,482 @@
+import { t } from '@lingui/core/macro';
+import { Trans } from '@lingui/react/macro';
+import {
+  Button,
+  Toolbar,
+  ToolbarContent,
+  ToolbarGroup,
+  ToolbarItem,
+} from '@patternfly/react-core';
+import { Table, Tbody, Td, Tr } from '@patternfly/react-table';
+import { Component } from 'react';
+import {
+  ContainerRemoteNativeAPI,
+  ExecutionEnvironmentRegistryAPI,
+  type ContainerRemoteNativeType,
+  type RemoteType,
+} from 'src/api';
+import { AppContext, type IAppContextType } from 'src/app-context';
+import {
+  AlertList,
+  type AlertType,
+  AppliedFilters,
+  BaseHeader,
+  CompoundFilter,
+  CopyURL,
+  DateComponent,
+  DeleteModal,
+  EmptyStateFilter,
+  EmptyStateNoData,
+  ListItemActions,
+  LoadingSpinner,
+  Main,
+  PulpPagination,
+  RemoteForm,
+  SortTable,
+  closeAlert,
+} from 'src/components';
+import {
+  type ErrorMessagesType,
+  ParamHelper,
+  type RouteProps,
+  filterIsSet,
+  jsxErrorMessage,
+  mapErrorMessages,
+  taskAlert,
+  withRouter,
+} from 'src/utilities';
+
+interface IState {
+  alerts: AlertType[];
+  itemCount: number;
+  items: ContainerRemoteNativeType[];
+  loading: boolean;
+  params: {
+    page?: number;
+    page_size?: number;
+  };
+  remoteFormErrors: ErrorMessagesType;
+  remoteFormNew: boolean;
+  remoteToEdit?: RemoteType;
+  remoteUnmodified?: RemoteType;
+  showDeleteModal: boolean;
+  showRemoteFormModal: boolean;
+  inputText: string;
+}
+
+class ExecutionEnvironmentRegistryList extends Component<RouteProps, IState> {
+  static contextType = AppContext;
+
+  constructor(props) {
+    super(props);
+
+    const params = ParamHelper.parseParamString(props.location.search, [
+      'page',
+      'page_size',
+    ]);
+
+    if (!params['page_size']) {
+      params['page_size'] = 10;
+    }
+
+    if (!params['sort']) {
+      params['sort'] = 'name';
+    }
+
+    this.state = {
+      alerts: [],
+      itemCount: 0,
+      items: [],
+      loading: true,
+      params,
+      remoteFormErrors: {},
+      remoteFormNew: false,
+      remoteToEdit: null,
+      remoteUnmodified: null,
+      showDeleteModal: false,
+      showRemoteFormModal: false,
+      inputText: '',
+    };
+  }
+
+  componentDidMount() {
+    this.queryRegistries();
+  }
+
+  render() {
+    const {
+      alerts,
+      itemCount,
+      items,
+      loading,
+      params,
+      remoteFormErrors,
+      remoteFormNew,
+      remoteToEdit,
+      remoteUnmodified,
+      showDeleteModal,
+      showRemoteFormModal,
+    } = this.state;
+    const noData =
+      items.length === 0 && !filterIsSet(params, ['name__icontains']);
+
+    const { hasPermission } = this.context as IAppContextType;
+    const addButton = hasPermission('galaxy.add_containerregistryremote') ? (
+      <Button
+        onClick={() =>
+          this.setState({
+            remoteFormErrors: {},
+            remoteFormNew: true,
+            remoteToEdit: {
+              name: '',
+              // API defaults to true when not sending anything, make the UI fit
+              tls_validation: true,
+              hidden_fields: [
+                { name: 'username', is_set: false },
+                { name: 'password', is_set: false },
+                { name: 'proxy_username', is_set: false },
+                { name: 'proxy_password', is_set: false },
+                { name: 'client_key', is_set: false },
+              ],
+            } as RemoteType,
+            remoteUnmodified: null,
+            showRemoteFormModal: true,
+          })
+        }
+      >
+        {t`Add remote registry`}
+      </Button>
+    ) : null;
+
+    return (
+      <>
+        <AlertList
+          alerts={alerts}
+          closeAlert={(i) =>
+            closeAlert(i, {
+              alerts,
+              setAlerts: (alerts) => this.setState({ alerts }),
+            })
+          }
+        />
+        {showRemoteFormModal && (
+          <RemoteForm
+            allowEditName={remoteFormNew}
+            closeModal={() =>
+              this.setState({
+                remoteToEdit: null,
+                remoteUnmodified: null,
+                showRemoteFormModal: false,
+              })
+            }
+            errorMessages={remoteFormErrors}
+            plugin='container'
+            remote={remoteToEdit}
+            saveRemote={() => {
+              const { remoteFormNew, remoteToEdit } = this.state;
+              const newRemote = { ...remoteToEdit };
+
+              if (remoteFormNew) {
+                // prevent "This field may not be blank." when writing in and then deleting username/password/etc
+                // only when creating, edit diffs with remoteUnmodified
+                Object.keys(newRemote).forEach((k) => {
+                  if (newRemote[k] === '' || newRemote[k] == null) {
+                    delete newRemote[k];
+                  }
+                });
+              }
+
+              const promise = remoteFormNew
+                ? ExecutionEnvironmentRegistryAPI.create(newRemote)
+                : ExecutionEnvironmentRegistryAPI.smartUpdate(
+                    remoteToEdit.id,
+                    remoteToEdit,
+                    remoteUnmodified,
+                  );
+
+              promise
+                .then(() => {
+                  this.setState(
+                    {
+                      remoteToEdit: null,
+                      remoteUnmodified: null,
+                      showRemoteFormModal: false,
+                    },
+                    () => this.queryRegistries(),
+                  );
+                })
+                .catch((err) =>
+                  this.setState({ remoteFormErrors: mapErrorMessages(err) }),
+                );
+            }}
+            showModal={showRemoteFormModal}
+            title={
+              remoteFormNew ? t`Add remote registry` : t`Edit remote registry`
+            }
+            updateRemote={(r: RemoteType) => this.setState({ remoteToEdit: r })}
+          />
+        )}
+        {showDeleteModal && remoteToEdit && (
+          <DeleteModal
+            cancelAction={() =>
+              this.setState({ showDeleteModal: false, remoteToEdit: null })
+            }
+            deleteAction={() => this.deleteRegistry(remoteToEdit)}
+            title={t`Delete remote registry?`}
+          >
+            <Trans>
+              <b>{remoteToEdit.name}</b> will be deleted.
+            </Trans>
+          </DeleteModal>
+        )}
+        <BaseHeader title={t`Remote registries`} />
+        {noData && !loading ? (
+          <EmptyStateNoData
+            title={t`No remote registries yet`}
+            description={t`You currently have no remote registries.`}
+            button={addButton}
+          />
+        ) : (
+          <Main>
+            {loading ? (
+              <LoadingSpinner />
+            ) : (
+              <section className='pulp-section'>
+                <div className='pulp-toolbar'>
+                  <Toolbar>
+                    <ToolbarContent>
+                      <ToolbarGroup>
+                        <ToolbarItem>
+                          <CompoundFilter
+                            inputText={this.state.inputText}
+                            onChange={(text) =>
+                              this.setState({ inputText: text })
+                            }
+                            updateParams={(p) =>
+                              this.updateParams(p, () => this.queryRegistries())
+                            }
+                            params={params}
+                            filterConfig={[
+                              {
+                                id: 'name__icontains',
+                                title: t`Name`,
+                              },
+                            ]}
+                          />
+                        </ToolbarItem>
+                        <ToolbarItem>{addButton}</ToolbarItem>
+                      </ToolbarGroup>
+                    </ToolbarContent>
+                  </Toolbar>
+
+                  <PulpPagination
+                    params={params}
+                    updateParams={(p) =>
+                      this.updateParams(p, () => this.queryRegistries())
+                    }
+                    count={itemCount}
+                    isTop
+                  />
+                </div>
+                <div>
+                  <AppliedFilters
+                    updateParams={(p) => {
+                      this.updateParams(p, () => this.queryRegistries());
+                      this.setState({ inputText: '' });
+                    }}
+                    params={params}
+                    ignoredParams={['page_size', 'page', 'sort']}
+                    niceNames={{
+                      name__icontains: t`Name`,
+                    }}
+                  />
+                </div>
+                {this.renderTable(params)}
+                <PulpPagination
+                  params={params}
+                  updateParams={(p) =>
+                    this.updateParams(p, () => this.queryRegistries())
+                  }
+                  count={itemCount}
+                />
+              </section>
+            )}
+          </Main>
+        )}
+      </>
+    );
+  }
+
+  private renderTable(params) {
+    const { items } = this.state;
+    if (items.length === 0) {
+      return <EmptyStateFilter />;
+    }
+
+    const sortTableOptions = {
+      headers: [
+        {
+          title: t`Name`,
+          type: 'alpha',
+          id: 'name',
+        },
+        {
+          title: t`Created`,
+          type: 'alpha',
+          id: 'created_at',
+        },
+        {
+          title: t`Last updated`,
+          type: 'alpha',
+          id: 'updated_at',
+        },
+        {
+          title: t`Registry URL`,
+          type: 'alpha',
+          id: 'url',
+        },
+        {
+          title: '',
+          type: 'none',
+          id: 'controls',
+        },
+      ],
+    };
+
+    return (
+      <Table>
+        <SortTable
+          options={sortTableOptions}
+          params={params}
+          updateParams={(p) =>
+            this.updateParams(p, () => this.queryRegistries())
+          }
+        />
+        <Tbody>{items.map((user, i) => this.renderTableRow(user, i))}</Tbody>
+      </Table>
+    );
+  }
+
+  private renderTableRow(item, index: number) {
+    return (
+      <Tr
+        data-cy={`ExecutionEnvironmentRegistryList-row-${item.name}`}
+        key={index}
+      >
+        <Td>{item.name}</Td>
+        <Td>
+          <DateComponent date={item.pulp_created} />
+        </Td>
+        <Td>
+          <DateComponent date={item.pulp_last_updated} />
+        </Td>
+        <Td>
+          <CopyURL url={item.url} />
+        </Td>
+        <ListItemActions kebabItems={[]} buttons={[]} />
+      </Tr>
+    );
+  }
+
+  private queryRegistries(noLoading = false) {
+    this.setState(noLoading ? null : { loading: true }, () =>
+      ContainerRemoteNativeAPI.list(this.state.params)
+        .then((result) => {
+          this.setState({
+            items: result.data.results,
+            itemCount: result.data.count,
+            loading: false,
+          });
+        })
+        .catch(() => {
+          this.setState({ loading: false });
+          this.addAlert(t`Remotes could not be loaded.`, 'danger');
+        }),
+    );
+  }
+
+  private deleteRegistry({ id, name }) {
+    ExecutionEnvironmentRegistryAPI.delete(id)
+      .then(() =>
+        this.addAlert(
+          t`Remote registry "${name}" has been successfully deleted.`,
+          'success',
+        ),
+      )
+      .catch((err) => {
+        const { status, statusText } = err.response;
+        this.addAlert(
+          t`Remote registry "${name}" could not be deleted.`,
+          'danger',
+          jsxErrorMessage(status, statusText),
+        );
+      })
+      .then(() => {
+        this.queryRegistries();
+        this.setState({ showDeleteModal: false, remoteToEdit: null });
+      });
+  }
+
+  private syncRegistry({ id, name }) {
+    ExecutionEnvironmentRegistryAPI.sync(id)
+      .then(({ data }) => {
+        this.addAlertObj(
+          taskAlert(data.task, t`Sync started for remote registry "${name}".`),
+        );
+        this.queryRegistries(true);
+      })
+      .catch((err) => {
+        const { status, statusText } = err.response;
+        this.addAlert(
+          t`Remote registry "${name}" could not be synced.`,
+          'danger',
+          jsxErrorMessage(status, statusText),
+        );
+      });
+  }
+
+  private indexRegistry({ id, name }) {
+    ExecutionEnvironmentRegistryAPI.index(id)
+      .then(({ data }) => {
+        this.addAlertObj(
+          taskAlert(
+            data.task,
+            t`Indexing started for container "${name}".`,
+            'success',
+          ),
+        );
+      })
+      .catch((err) => {
+        const { status, statusText } = err.response;
+        this.addAlert(
+          t`Container "${name}" could not be indexed.`,
+          'danger',
+          jsxErrorMessage(status, statusText),
+        );
+      });
+  }
+
+  private addAlertObj(alert: AlertType) {
+    this.setState({
+      alerts: [...this.state.alerts, alert],
+    });
+  }
+
+  private addAlert(title, variant, description?) {
+    this.addAlertObj({
+      description,
+      title,
+      variant,
+    });
+  }
+
+  private updateParams(params, callback = null) {
+    ParamHelper.updateParams({
+      params,
+      navigate: (to) => this.props.navigate(to),
+      setState: (state) => this.setState(state, callback),
+    });
+  }
+}
+
+export default withRouter(ExecutionEnvironmentRegistryList);

--- a/src/containers/execution-environment/registry-list-native.tsx
+++ b/src/containers/execution-environment/registry-list-native.tsx
@@ -1,5 +1,4 @@
 import { t } from '@lingui/core/macro';
-import { Trans } from '@lingui/react/macro';
 import {
   Button,
   Toolbar,
@@ -11,8 +10,8 @@ import { Table, Tbody, Td, Tr } from '@patternfly/react-table';
 import { Component } from 'react';
 import {
   ContainerRemoteNativeAPI,
-  ExecutionEnvironmentRegistryAPI,
   type ContainerRemoteNativeType,
+  ExecutionEnvironmentRegistryAPI,
   type RemoteType,
 } from 'src/api';
 import { AppContext, type IAppContextType } from 'src/app-context';
@@ -24,7 +23,6 @@ import {
   CompoundFilter,
   CopyURL,
   DateComponent,
-  DeleteModal,
   EmptyStateFilter,
   EmptyStateNoData,
   ListItemActions,
@@ -40,9 +38,7 @@ import {
   ParamHelper,
   type RouteProps,
   filterIsSet,
-  jsxErrorMessage,
   mapErrorMessages,
-  taskAlert,
   withRouter,
 } from 'src/utilities';
 
@@ -59,7 +55,6 @@ interface IState {
   remoteFormNew: boolean;
   remoteToEdit?: RemoteType;
   remoteUnmodified?: RemoteType;
-  showDeleteModal: boolean;
   showRemoteFormModal: boolean;
   inputText: string;
 }
@@ -93,7 +88,6 @@ class ExecutionEnvironmentRegistryList extends Component<RouteProps, IState> {
       remoteFormNew: false,
       remoteToEdit: null,
       remoteUnmodified: null,
-      showDeleteModal: false,
       showRemoteFormModal: false,
       inputText: '',
     };
@@ -114,7 +108,6 @@ class ExecutionEnvironmentRegistryList extends Component<RouteProps, IState> {
       remoteFormNew,
       remoteToEdit,
       remoteUnmodified,
-      showDeleteModal,
       showRemoteFormModal,
     } = this.state;
     const noData =
@@ -215,19 +208,6 @@ class ExecutionEnvironmentRegistryList extends Component<RouteProps, IState> {
             }
             updateRemote={(r: RemoteType) => this.setState({ remoteToEdit: r })}
           />
-        )}
-        {showDeleteModal && remoteToEdit && (
-          <DeleteModal
-            cancelAction={() =>
-              this.setState({ showDeleteModal: false, remoteToEdit: null })
-            }
-            deleteAction={() => this.deleteRegistry(remoteToEdit)}
-            title={t`Delete remote registry?`}
-          >
-            <Trans>
-              <b>{remoteToEdit.name}</b> will be deleted.
-            </Trans>
-          </DeleteModal>
         )}
         <BaseHeader title={t`Remote registries`} />
         {noData && !loading ? (
@@ -373,7 +353,9 @@ class ExecutionEnvironmentRegistryList extends Component<RouteProps, IState> {
         <Td>
           <CopyURL url={item.url} />
         </Td>
-        <ListItemActions kebabItems={[]} buttons={[]} />
+        <Td isActionCell>
+          <ListItemActions kebabItems={[]} buttons={[]} />
+        </Td>
       </Tr>
     );
   }
@@ -393,67 +375,6 @@ class ExecutionEnvironmentRegistryList extends Component<RouteProps, IState> {
           this.addAlert(t`Remotes could not be loaded.`, 'danger');
         }),
     );
-  }
-
-  private deleteRegistry({ id, name }) {
-    ExecutionEnvironmentRegistryAPI.delete(id)
-      .then(() =>
-        this.addAlert(
-          t`Remote registry "${name}" has been successfully deleted.`,
-          'success',
-        ),
-      )
-      .catch((err) => {
-        const { status, statusText } = err.response;
-        this.addAlert(
-          t`Remote registry "${name}" could not be deleted.`,
-          'danger',
-          jsxErrorMessage(status, statusText),
-        );
-      })
-      .then(() => {
-        this.queryRegistries();
-        this.setState({ showDeleteModal: false, remoteToEdit: null });
-      });
-  }
-
-  private syncRegistry({ id, name }) {
-    ExecutionEnvironmentRegistryAPI.sync(id)
-      .then(({ data }) => {
-        this.addAlertObj(
-          taskAlert(data.task, t`Sync started for remote registry "${name}".`),
-        );
-        this.queryRegistries(true);
-      })
-      .catch((err) => {
-        const { status, statusText } = err.response;
-        this.addAlert(
-          t`Remote registry "${name}" could not be synced.`,
-          'danger',
-          jsxErrorMessage(status, statusText),
-        );
-      });
-  }
-
-  private indexRegistry({ id, name }) {
-    ExecutionEnvironmentRegistryAPI.index(id)
-      .then(({ data }) => {
-        this.addAlertObj(
-          taskAlert(
-            data.task,
-            t`Indexing started for container "${name}".`,
-            'success',
-          ),
-        );
-      })
-      .catch((err) => {
-        const { status, statusText } = err.response;
-        this.addAlert(
-          t`Container "${name}" could not be indexed.`,
-          'danger',
-          jsxErrorMessage(status, statusText),
-        );
-      });
   }
 
   private addAlertObj(alert: AlertType) {

--- a/src/containers/index.ts
+++ b/src/containers/index.ts
@@ -13,13 +13,13 @@ export { default as CollectionDistributions } from './collection-detail/collecti
 export { default as CollectionDocs } from './collection-detail/collection-docs';
 export { default as CollectionImportLog } from './collection-detail/collection-import-log';
 export { default as EditNamespace } from './edit-namespace/edit-namespace';
-export { default as ExecutionEnvironmentDetail } from './execution-environment-detail/execution-environment-detail';
+export { default as ExecutionEnvironmentDetail } from './execution-environment-detail/execution-environment-detail-native';
 export { default as ExecutionEnvironmentDetailAccess } from './execution-environment-detail/execution-environment-detail-access';
 export { default as ExecutionEnvironmentDetailActivities } from './execution-environment-detail/execution-environment-detail-activities';
 export { default as ExecutionEnvironmentDetailImages } from './execution-environment-detail/execution-environment-detail-images';
-export { default as ExecutionEnvironmentList } from './execution-environment-list/execution-environment-list';
+export { default as ExecutionEnvironmentList } from './execution-environment-list/execution-environment-list-native';
 export { default as ExecutionEnvironmentManifest } from './execution-environment-manifest/execution-environment-manifest';
-export { default as ExecutionEnvironmentRegistryList } from './execution-environment/registry-list';
+export { default as ExecutionEnvironmentRegistryList } from './execution-environment/registry-list-native';
 export { default as FileRemoteDetail } from './file-remote/detail';
 export { default as FileRemoteEdit } from './file-remote/edit';
 export { default as FileRemoteList } from './file-remote/list';

--- a/src/menu.tsx
+++ b/src/menu.tsx
@@ -91,11 +91,9 @@ function standaloneMenu() {
       [
         menuItem(t`Containers`, {
           url: formatPath(Paths.container.repository.list),
-          condition: BROKEN,
         }),
         menuItem(t`Remote registries`, {
           url: formatPath(Paths.container.remote.list),
-          condition: BROKEN,
         }),
       ],
     ),


### PR DESCRIPTION
- add read-only container repository sidebar grouped by local/remote
- add native container detail tabs: Details, Versions, Distributions
- show version-level pull references with tag and digest
- support href-based loading for container-push repositories
- keep original container files untouched by using native variant files