### PR TITLE
Add shared base types for Repositories, Publications, Remotes and Distributions

### DIFF
--- a/src/api/ansible-distribution.ts
+++ b/src/api/ansible-distribution.ts
@@ -3,10 +3,13 @@ import { PulpAPI } from './pulp';
 
 /**
  * Ansible Distribution Type.
- * 
+ *
  * @see https://github.com/pulp/pulp_ansible/blob/0043923641fc7fd3893f8489fd29ff04addc9d71/pulp_ansible/app/serializers.py#L356
  */
-interface AnsibleDistributionType extends Omit<GenericDistribution, 'base_url'> {
+interface AnsibleDistributionType extends Omit<
+  GenericDistribution,
+  'base_url'
+> {
   readonly client_url: string;
   repository_version?: string | null;
 }

--- a/src/api/ansible-distribution.ts
+++ b/src/api/ansible-distribution.ts
@@ -1,4 +1,15 @@
+import type { GenericDistribution } from './common';
 import { PulpAPI } from './pulp';
+
+/**
+ * Ansible Distribution Type.
+ * 
+ * @see https://github.com/pulp/pulp_ansible/blob/0043923641fc7fd3893f8489fd29ff04addc9d71/pulp_ansible/app/serializers.py#L356
+ */
+interface AnsibleDistributionType extends Omit<GenericDistribution, 'base_url'> {
+  readonly client_url: string;
+  repository_version?: string | null;
+}
 
 const base = new PulpAPI();
 
@@ -11,3 +22,5 @@ export const AnsibleDistributionAPI = {
 
   url: (distro_data) => distro_data.client_url,
 };
+
+export type { AnsibleDistributionType };

--- a/src/api/ansible-remote.ts
+++ b/src/api/ansible-remote.ts
@@ -1,6 +1,11 @@
 import type { AnsibleLastSyncType, GenericRemote } from './common';
 import { PulpAPI } from './pulp';
 
+/**
+ * Ansible Remote Type.
+ *
+ * @see https://github.com/pulp/pulp_ansible/blob/0043923641fc7fd3893f8489fd29ff04addc9d71/pulp_ansible/app/serializers.py#L213
+ */
 interface AnsibleRemoteType extends GenericRemote {
   requirements_file?: string | null;
   auth_url?: string | null;
@@ -9,7 +14,7 @@ interface AnsibleRemoteType extends GenericRemote {
   signed_only?: boolean;
   readonly last_sync_task?: AnsibleLastSyncType | null;
   /**
-   * NOTE: Not part of the Ansible serializer, populated separately. 
+   * NOTE: Not part of the Ansible serializer, populated separately.
    * This should be broken out into its own type and extend the interface.
    */
   my_permissions?: string[];
@@ -72,4 +77,4 @@ export const AnsibleRemoteAPI = {
     ),
 };
 
-export type { AnsibleRemoteType }
+export type { AnsibleRemoteType };

--- a/src/api/ansible-remote.ts
+++ b/src/api/ansible-remote.ts
@@ -1,36 +1,17 @@
+import type { AnsibleLastSyncType, GenericRemote } from './common';
 import { PulpAPI } from './pulp';
 
-export class AnsibleRemoteType {
-  auth_url: string;
-  ca_cert: string;
-  client_cert: string;
-  download_concurrency: number;
-  name: string;
-  proxy_url: string;
-  pulp_href?: string;
-  rate_limit: number;
-  requirements_file: string;
-  tls_validation: boolean;
-  url: string;
-  signed_only: boolean;
+interface AnsibleRemoteType extends GenericRemote {
+  requirements_file?: string | null;
+  auth_url?: string | null;
+  token?: string | null;
   sync_dependencies?: boolean;
-
-  // connect_timeout
-  // headers
-  // max_retries
-  // policy
-  // pulp_created
-  // pulp_labels
-  // pulp_last_updated
-  // sock_connect_timeout
-  // sock_read_timeout
-  // total_timeout
-
-  hidden_fields: {
-    is_set: boolean;
-    name: string;
-  }[];
-
+  signed_only?: boolean;
+  readonly last_sync_task?: AnsibleLastSyncType | null;
+  /**
+   * NOTE: Not part of the Ansible serializer, populated separately. 
+   * This should be broken out into its own type and extend the interface.
+   */
   my_permissions?: string[];
 }
 
@@ -90,3 +71,5 @@ export const AnsibleRemoteAPI = {
       smartUpdate(newValue, oldValue),
     ),
 };
+
+export type { AnsibleRemoteType }

--- a/src/api/ansible-repository.ts
+++ b/src/api/ansible-repository.ts
@@ -1,22 +1,17 @@
+import type { GenericRepository, LastSyncType } from './common';
 import { PulpAPI } from './pulp';
-import { type LastSyncType } from './response-types/remote';
 
-export class AnsibleRepositoryType {
-  description: string;
-  last_sync_task?: LastSyncType;
-  latest_version_href?: string;
-  name: string;
+/**
+ * Ansible Repository Type.
+ * 
+ * @see https://github.com/pulp/pulp_ansible/blob/main/pulp_ansible/app/serializers.py
+ */
+interface AnsibleRepositoryType extends GenericRepository {
+  last_synced_metadata_time?: string | null;
+  gpgkey?: string | null;
+  readonly last_sync_task?: LastSyncType;
   private?: boolean;
-  pulp_created?: string;
-  pulp_href?: string;
-  pulp_labels?: Record<string, string>;
-  remote?: string;
-  retain_repo_versions: number;
-
-  // gpgkey
-  // last_synced_metadata_time
-  // versions_href
-
+  // NOTE: Not part of the Ansible serializer, populated separately.
   my_permissions?: string[];
 }
 
@@ -91,3 +86,5 @@ export const AnsibleRepositoryAPI = {
   update: (id: string, data) =>
     base.http.put(`repositories/ansible/ansible/${id}/`, data),
 };
+
+export type { AnsibleRepositoryType }

--- a/src/api/ansible-repository.ts
+++ b/src/api/ansible-repository.ts
@@ -12,7 +12,7 @@ interface AnsibleRepositoryType extends GenericRepository {
   readonly last_sync_task?: AnsibleLastSyncType | null;
   private?: boolean;
   /**
-   * NOTE: Not part of the Ansible serializer, populated separately. 
+   * NOTE: Not part of the Ansible serializer, populated separately.
    * This should be broken out into its own type and extend the interface.
    */
   my_permissions?: string[];

--- a/src/api/ansible-repository.ts
+++ b/src/api/ansible-repository.ts
@@ -1,29 +1,15 @@
-import type { GenericRepository, TaskErrorType } from './common';
+import type { AnsibleLastSyncType, GenericRepository } from './common';
 import { PulpAPI } from './pulp';
-import type { PulpStatus } from './response-types/pulp';
-
-/**
- * Last Sync Task Type.
- *
- * @see https://github.com/pulp/pulp_ansible/blob/main/pulp_ansible/app/utils.py
- */
-interface LastSyncType {
-  pk: string;
-  state: PulpStatus;
-  pulp_created: string;
-  finished_at: string | null;
-  error: TaskErrorType | null;
-}
 
 /**
  * Ansible Repository Type.
  *
- * @see https://github.com/pulp/pulp_ansible/blob/main/pulp_ansible/app/serializers.py
+ * @see https://github.com/pulp/pulp_ansible/blob/0043923641fc7fd3893f8489fd29ff04addc9d71/pulp_ansible/app/serializers.py#L148
  */
 interface AnsibleRepositoryType extends GenericRepository {
   last_synced_metadata_time?: string | null;
   gpgkey?: string | null;
-  readonly last_sync_task?: LastSyncType | null;
+  readonly last_sync_task?: AnsibleLastSyncType | null;
   private?: boolean;
   /**
    * NOTE: Not part of the Ansible serializer, populated separately. 

--- a/src/api/ansible-repository.ts
+++ b/src/api/ansible-repository.ts
@@ -3,7 +3,7 @@ import { PulpAPI } from './pulp';
 
 /**
  * Ansible Repository Type.
- * 
+ *
  * @see https://github.com/pulp/pulp_ansible/blob/main/pulp_ansible/app/serializers.py
  */
 interface AnsibleRepositoryType extends GenericRepository {
@@ -87,4 +87,4 @@ export const AnsibleRepositoryAPI = {
     base.http.put(`repositories/ansible/ansible/${id}/`, data),
 };
 
-export type { AnsibleRepositoryType }
+export type { AnsibleRepositoryType };

--- a/src/api/ansible-repository.ts
+++ b/src/api/ansible-repository.ts
@@ -1,5 +1,19 @@
-import type { GenericRepository, LastSyncType } from './common';
+import type { GenericRepository, TaskErrorType } from './common';
 import { PulpAPI } from './pulp';
+import type { PulpStatus } from './response-types/pulp';
+
+/**
+ * Last Sync Task Type.
+ *
+ * @see https://github.com/pulp/pulp_ansible/blob/main/pulp_ansible/app/utils.py
+ */
+interface LastSyncType {
+  pk: string;
+  state: PulpStatus;
+  pulp_created: string;
+  finished_at: string | null;
+  error: TaskErrorType | null;
+}
 
 /**
  * Ansible Repository Type.
@@ -9,9 +23,12 @@ import { PulpAPI } from './pulp';
 interface AnsibleRepositoryType extends GenericRepository {
   last_synced_metadata_time?: string | null;
   gpgkey?: string | null;
-  readonly last_sync_task?: LastSyncType;
+  readonly last_sync_task?: LastSyncType | null;
   private?: boolean;
-  // NOTE: Not part of the Ansible serializer, populated separately.
+  /**
+   * NOTE: Not part of the Ansible serializer, populated separately. 
+   * This should be broken out into its own type and extend the interface.
+   */
   my_permissions?: string[];
 }
 

--- a/src/api/common.ts
+++ b/src/api/common.ts
@@ -16,14 +16,14 @@ interface GenericResource {
  * @see https://github.com/pulp/pulpcore/blob/main/pulpcore/app/serializers/repository.py
  */
 interface GenericRepository extends GenericResource {
-    readonly pulp_labels?: Record<string, string>;
+    pulp_labels?: Record<string, string>;
     readonly versions_href?: string;
     readonly latest_version_href?: string;
-    readonly name: string;
-    readonly description: string | null;
-    readonly retain_repo_versions: string | null;
-    readonly retain_checkpoints: string | null;
-    readonly remote: string | null;
+    name: string;
+    description?: string | null;
+    retain_repo_versions?: number | null;
+    retain_checkpoints?: number | null;
+    remote?: string | null;
 }
 
 export type { GenericRepository }

--- a/src/api/common.ts
+++ b/src/api/common.ts
@@ -1,3 +1,5 @@
+import type { PulpStatus } from "./response-types/pulp";
+
 /**
  * Generic PulpCore Exceptions based on dictionary representation.
  * @see https://github.com/pulp/pulpcore/blob/main/pulpcore/exceptions/base.py
@@ -64,4 +66,55 @@ interface GenericPublication extends GenericResource {
   repository?: string;
 }
 
-export type { TaskErrorType, GenericRepository, GenericDistribution, GenericPublication };
+/**
+ * Generic Remote shared across Pulp Remote plugins.
+ * 
+ * @see https://github.com/pulp/pulpcore/blob/934c752dae916857b2005e1fe0ef75496accc082/pulpcore/app/serializers/repository.py#L85
+ * @see https://github.com/pulp/pulpcore/blob/934c752dae916857b2005e1fe0ef75496accc082/pulpcore/app/serializers/base.py#L612
+ * @see https://github.com/pulp/pulpcore/blob/934c752dae916857b2005e1fe0ef75496accc082/pulpcore/app/serializers/base.py#L367
+ */
+interface GenericRemote extends GenericResource {
+  pulp_labels?: Record<string, string>;
+  name: string;
+  url: string;
+  policy?: string;
+  readonly hidden_fields?: { name: string; is_set: boolean; }[];
+  ca_cert?: string | null;
+  client_cert?: string | null;
+  client_key?: string | null;
+  tls_validation?: boolean;
+  proxy_url?: string | null;
+  proxy_username?: string | null;
+  proxy_password?: string | null;
+  username?: string | null;
+  password?: string | null;
+  max_retries?: number | null;
+  total_timeout?: number | null;
+  connect_timeout?: number | null;
+  sock_connect_timeout?: number | null;
+  sock_read_timeout?: number | null;
+  headers?: unknown[];
+  download_concurrency?: number | null;
+  rate_limit?: number | null;
+}
+
+/**
+ * --------------------
+ * These are shared Plugin Types outside the PulpCore Generics.
+ * --------------------
+ */
+
+/**
+ * Last Sync Task Type.
+ *
+ * @see https://github.com/pulp/pulp_ansible/blob/main/pulp_ansible/app/utils.py
+ */
+interface AnsibleLastSyncType {
+  pk: string;
+  state: PulpStatus;
+  pulp_created: string;
+  finished_at: string | null;
+  error: TaskErrorType | null;
+}
+
+export type { TaskErrorType, GenericRepository, GenericDistribution, GenericPublication, GenericRemote, AnsibleLastSyncType };

--- a/src/api/common.ts
+++ b/src/api/common.ts
@@ -1,0 +1,29 @@
+/**
+ * Generic Resource shared across every Pulp resource.
+ * 
+ * @see https://github.com/pulp/pulpcore/blob/main/pulpcore/app/serializers/base.py
+ */
+interface GenericResource {
+    readonly pulp_href?: string;
+    readonly prn?: string;
+    readonly pulp_created?: string;
+    readonly pulp_last_updated?: string;
+}
+
+/**
+ * Generic Repository shared across Pulp Repository plugins.
+ * 
+ * @see https://github.com/pulp/pulpcore/blob/main/pulpcore/app/serializers/repository.py
+ */
+interface GenericRepository extends GenericResource {
+    readonly pulp_labels?: Record<string, string>;
+    readonly versions_href?: string;
+    readonly latest_version_href?: string;
+    readonly name: string;
+    readonly description: string | null;
+    readonly retain_repo_versions: string | null;
+    readonly retain_checkpoints: string | null;
+    readonly remote: string | null;
+}
+
+export type { GenericRepository }

--- a/src/api/common.ts
+++ b/src/api/common.ts
@@ -1,5 +1,3 @@
-import type { PulpStatus } from './response-types/pulp';
-
 /**
  * Generic PulpCore Exceptions based on dictionary representation.
  * @see https://github.com/pulp/pulpcore/blob/main/pulpcore/exceptions/base.py
@@ -38,23 +36,4 @@ interface GenericRepository extends GenericResource {
   remote?: string | null;
 }
 
-/**
- * --------------------
- * Shared types reused across multiple resource types but not part of pulpcore generic types.
- * --------------------
- */
-
-/**
- * Last Sync Task Type.
- *
- * @see https://github.com/pulp/pulp_ansible/blob/main/pulp_ansible/app/utils.py
- */
-interface LastSyncType {
-  pk: string;
-  state: PulpStatus;
-  pulp_created: string;
-  finished_at: string;
-  error: TaskErrorType;
-}
-
-export type { TaskErrorType, GenericRepository, LastSyncType };
+export type { TaskErrorType, GenericRepository };

--- a/src/api/common.ts
+++ b/src/api/common.ts
@@ -1,3 +1,15 @@
+import type { PulpStatus } from "./response-types/pulp";
+
+/**
+ * Generic PulpCore Exceptions based on dictionary representation.
+ * @see https://github.com/pulp/pulpcore/blob/main/pulpcore/exceptions/base.py
+ */
+interface TaskErrorType {
+    description: string;
+    traceback: string | null;
+    error_code?: string;
+}
+
 /**
  * Generic Resource shared across every Pulp resource.
  * 
@@ -26,4 +38,23 @@ interface GenericRepository extends GenericResource {
     remote?: string | null;
 }
 
-export type { GenericRepository }
+/**
+ * --------------------
+ * Shared types reused across multiple resource types but not part of pulpcore generic types.
+ * --------------------
+ */
+
+/**
+ * Last Sync Task Type.
+ * 
+ * @see https://github.com/pulp/pulp_ansible/blob/main/pulp_ansible/app/utils.py
+ */
+interface LastSyncType {
+    pk: string;
+    state: PulpStatus;
+    pulp_created: string;
+    finished_at: string;
+    error: TaskErrorType;
+}
+
+export type { TaskErrorType, GenericRepository, LastSyncType }

--- a/src/api/common.ts
+++ b/src/api/common.ts
@@ -1,41 +1,41 @@
-import type { PulpStatus } from "./response-types/pulp";
+import type { PulpStatus } from './response-types/pulp';
 
 /**
  * Generic PulpCore Exceptions based on dictionary representation.
  * @see https://github.com/pulp/pulpcore/blob/main/pulpcore/exceptions/base.py
  */
 interface TaskErrorType {
-    description: string;
-    traceback: string | null;
-    error_code?: string;
+  description: string;
+  traceback: string | null;
+  error_code?: string;
 }
 
 /**
  * Generic Resource shared across every Pulp resource.
- * 
+ *
  * @see https://github.com/pulp/pulpcore/blob/main/pulpcore/app/serializers/base.py
  */
 interface GenericResource {
-    readonly pulp_href?: string;
-    readonly prn?: string;
-    readonly pulp_created?: string;
-    readonly pulp_last_updated?: string;
+  readonly pulp_href?: string;
+  readonly prn?: string;
+  readonly pulp_created?: string;
+  readonly pulp_last_updated?: string;
 }
 
 /**
  * Generic Repository shared across Pulp Repository plugins.
- * 
+ *
  * @see https://github.com/pulp/pulpcore/blob/main/pulpcore/app/serializers/repository.py
  */
 interface GenericRepository extends GenericResource {
-    pulp_labels?: Record<string, string>;
-    readonly versions_href?: string;
-    readonly latest_version_href?: string;
-    name: string;
-    description?: string | null;
-    retain_repo_versions?: number | null;
-    retain_checkpoints?: number | null;
-    remote?: string | null;
+  pulp_labels?: Record<string, string>;
+  readonly versions_href?: string;
+  readonly latest_version_href?: string;
+  name: string;
+  description?: string | null;
+  retain_repo_versions?: number | null;
+  retain_checkpoints?: number | null;
+  remote?: string | null;
 }
 
 /**
@@ -46,15 +46,15 @@ interface GenericRepository extends GenericResource {
 
 /**
  * Last Sync Task Type.
- * 
+ *
  * @see https://github.com/pulp/pulp_ansible/blob/main/pulp_ansible/app/utils.py
  */
 interface LastSyncType {
-    pk: string;
-    state: PulpStatus;
-    pulp_created: string;
-    finished_at: string;
-    error: TaskErrorType;
+  pk: string;
+  state: PulpStatus;
+  pulp_created: string;
+  finished_at: string;
+  error: TaskErrorType;
 }
 
-export type { TaskErrorType, GenericRepository, LastSyncType }
+export type { TaskErrorType, GenericRepository, LastSyncType };

--- a/src/api/common.ts
+++ b/src/api/common.ts
@@ -1,8 +1,8 @@
-import type { PulpStatus } from "./response-types/pulp";
+import type { PulpStatus } from './response-types/pulp';
 
 /**
  * Generic PulpCore Exceptions based on dictionary representation.
- * @see https://github.com/pulp/pulpcore/blob/main/pulpcore/exceptions/base.py
+ * @see https://github.com/pulp/pulpcore/blob/934c752dae916857b2005e1fe0ef75496accc082/pulpcore/exceptions/base.py#L37
  */
 interface TaskErrorType {
   description: string;
@@ -25,7 +25,7 @@ interface GenericResource {
 /**
  * Generic Repository shared across Pulp Repository plugins.
  *
- * @see https://github.com/pulp/pulpcore/blob/main/pulpcore/app/serializers/repository.py
+ * @see https://github.com/pulp/pulpcore/blob/934c752dae916857b2005e1fe0ef75496accc082/pulpcore/app/serializers/repository.py#L26
  */
 interface GenericRepository extends GenericResource {
   pulp_labels?: Record<string, string>;
@@ -40,7 +40,7 @@ interface GenericRepository extends GenericResource {
 
 /**
  * Generic Distribution shared across Pulp Distribution plugins.
- * 
+ *
  * @see https://github.com/pulp/pulpcore/blob/934c752dae916857b2005e1fe0ef75496accc082/pulpcore/app/serializers/publication.py
  */
 interface GenericDistribution extends GenericResource {
@@ -58,7 +58,7 @@ interface GenericDistribution extends GenericResource {
 
 /**
  * Generic Publication shared across Pulp Publication plugins.
- * 
+ *
  * @see https://github.com/pulp/pulpcore/blob/934c752dae916857b2005e1fe0ef75496accc082/pulpcore/app/serializers/publication.py#L23
  */
 interface GenericPublication extends GenericResource {
@@ -68,7 +68,7 @@ interface GenericPublication extends GenericResource {
 
 /**
  * Generic Remote shared across Pulp Remote plugins.
- * 
+ *
  * @see https://github.com/pulp/pulpcore/blob/934c752dae916857b2005e1fe0ef75496accc082/pulpcore/app/serializers/repository.py#L85
  * @see https://github.com/pulp/pulpcore/blob/934c752dae916857b2005e1fe0ef75496accc082/pulpcore/app/serializers/base.py#L612
  * @see https://github.com/pulp/pulpcore/blob/934c752dae916857b2005e1fe0ef75496accc082/pulpcore/app/serializers/base.py#L367
@@ -78,7 +78,7 @@ interface GenericRemote extends GenericResource {
   name: string;
   url: string;
   policy?: string;
-  readonly hidden_fields?: { name: string; is_set: boolean; }[];
+  readonly hidden_fields?: { name: string; is_set: boolean }[];
   ca_cert?: string | null;
   client_cert?: string | null;
   client_key?: string | null;
@@ -107,7 +107,7 @@ interface GenericRemote extends GenericResource {
 /**
  * Last Sync Task Type.
  *
- * @see https://github.com/pulp/pulp_ansible/blob/main/pulp_ansible/app/utils.py
+ * @see https://github.com/pulp/pulp_ansible/blob/0043923641fc7fd3893f8489fd29ff04addc9d71/pulp_ansible/app/utils.py#L47
  */
 interface AnsibleLastSyncType {
   pk: string;
@@ -117,4 +117,11 @@ interface AnsibleLastSyncType {
   error: TaskErrorType | null;
 }
 
-export type { TaskErrorType, GenericRepository, GenericDistribution, GenericPublication, GenericRemote, AnsibleLastSyncType };
+export type {
+  TaskErrorType,
+  GenericRepository,
+  GenericDistribution,
+  GenericPublication,
+  GenericRemote,
+  AnsibleLastSyncType,
+};

--- a/src/api/common.ts
+++ b/src/api/common.ts
@@ -54,4 +54,14 @@ interface GenericDistribution extends GenericResource {
   repository_version?: string;
 }
 
-export type { TaskErrorType, GenericRepository, GenericDistribution };
+/**
+ * Generic Publication shared across Pulp Publication plugins.
+ * 
+ * @see https://github.com/pulp/pulpcore/blob/934c752dae916857b2005e1fe0ef75496accc082/pulpcore/app/serializers/publication.py#L23
+ */
+interface GenericPublication extends GenericResource {
+  repository_version?: string;
+  repository?: string;
+}
+
+export type { TaskErrorType, GenericRepository, GenericDistribution, GenericPublication };

--- a/src/api/common.ts
+++ b/src/api/common.ts
@@ -11,7 +11,7 @@ interface TaskErrorType {
 /**
  * Generic Resource shared across every Pulp resource.
  *
- * @see https://github.com/pulp/pulpcore/blob/main/pulpcore/app/serializers/base.py
+ * @see https://github.com/pulp/pulpcore/blob/934c752dae916857b2005e1fe0ef75496accc082/pulpcore/app/serializers/base.py#L448
  */
 interface GenericResource {
   readonly pulp_href?: string;
@@ -36,4 +36,22 @@ interface GenericRepository extends GenericResource {
   remote?: string | null;
 }
 
-export type { TaskErrorType, GenericRepository };
+/**
+ * Generic Distribution shared across Pulp Distribution plugins.
+ * 
+ * @see https://github.com/pulp/pulpcore/blob/934c752dae916857b2005e1fe0ef75496accc082/pulpcore/app/serializers/publication.py
+ */
+interface GenericDistribution extends GenericResource {
+  base_path: string;
+  readonly base_url?: string;
+  content_guard?: string | null;
+  readonly content_guard_prn?: string | null;
+  readonly no_content_change_since?: string | null;
+  hidden?: boolean;
+  pulp_labels?: Record<string, string>;
+  name: string;
+  repository?: string;
+  repository_version?: string;
+}
+
+export type { TaskErrorType, GenericRepository, GenericDistribution };

--- a/src/api/container-distribution.ts
+++ b/src/api/container-distribution.ts
@@ -1,4 +1,42 @@
+import type { GenericDistribution } from './common';
 import { PulpAPI } from './pulp';
+
+/**
+ * Container Distribution Type.
+ *
+ * @see https://github.com/pulp/pulp_container/blob/b109af03cb7aae3431f7a73204e6a73a8457694c/pulp_container/app/serializers.py#L424
+ */
+interface ContainerDistributionType extends Omit<
+  GenericDistribution,
+  'base_url'
+> {
+  readonly registry_path: string;
+  content_guard?: string;
+  readonly namespace?: string;
+  description?: string | null;
+  repository_version?: string | null;
+  readonly remote?: string;
+  private?: boolean;
+  readonly pulp_domain?: string;
+}
+
+/**
+ * Container Pull Through Type.
+ *
+ * @see https://github.com/pulp/pulp_container/blob/b109af03cb7aae3431f7a73204e6a73a8457694c/pulp_container/app/serializers.py#L520
+ */
+interface ContainerPullThroughDistributionType extends Omit<
+  GenericDistribution,
+  'base_url'
+> {
+  remote: string;
+  readonly namespace?: string;
+  content_guard?: string;
+  distributions?: string[];
+  description?: string | null;
+  private?: boolean;
+  readonly pulp_domain?: string;
+}
 
 const base = new PulpAPI();
 
@@ -17,3 +55,5 @@ export const ContainerPullThroughDistributionAPI = {
   // We should probably put this into a field on the serializer
   url: (distro_data) => `${window.location.host}/${distro_data.base_path}/`,
 };
+
+export type { ContainerDistributionType, ContainerPullThroughDistributionType };

--- a/src/api/file-distribution.ts
+++ b/src/api/file-distribution.ts
@@ -1,4 +1,15 @@
+import type { GenericDistribution } from './common';
 import { PulpAPI } from './pulp';
+
+/**
+ * File Distribution Type.
+ * 
+ * @see https://github.com/pulp/pulpcore/blob/934c752dae916857b2005e1fe0ef75496accc082/pulp_file/app/serializers.py#L225
+ */
+interface FileDistributionType extends GenericDistribution {
+  publication?: string | null;
+  checkpoint?: boolean;
+}
 
 const base = new PulpAPI();
 
@@ -9,3 +20,5 @@ export const FileDistributionAPI = {
 
   list: (params?) => base.list(`distributions/file/file/`, params),
 };
+
+export type { FileDistributionType }

--- a/src/api/file-distribution.ts
+++ b/src/api/file-distribution.ts
@@ -3,7 +3,7 @@ import { PulpAPI } from './pulp';
 
 /**
  * File Distribution Type.
- * 
+ *
  * @see https://github.com/pulp/pulpcore/blob/934c752dae916857b2005e1fe0ef75496accc082/pulp_file/app/serializers.py#L225
  */
 interface FileDistributionType extends GenericDistribution {
@@ -21,4 +21,4 @@ export const FileDistributionAPI = {
   list: (params?) => base.list(`distributions/file/file/`, params),
 };
 
-export type { FileDistributionType }
+export type { FileDistributionType };

--- a/src/api/file-publication.ts
+++ b/src/api/file-publication.ts
@@ -1,4 +1,16 @@
+import type { GenericPublication } from './common';
 import { PulpAPI } from './pulp';
+
+/**
+ * File Publication Type.
+ * 
+ * @see https://github.com/pulp/pulpcore/blob/934c752dae916857b2005e1fe0ef75496accc082/pulp_file/app/serializers.py#L200
+ */
+interface FilePublicationType extends GenericPublication {
+  readonly distributions: string[];
+  manifest?: string | null;
+  checkpoint?: boolean;
+}
 
 const base = new PulpAPI();
 
@@ -9,3 +21,5 @@ export const FilePublicationAPI = {
 
   list: (params?) => base.list(`publications/file/file/`, params),
 };
+
+export type { FilePublicationType };

--- a/src/api/file-publication.ts
+++ b/src/api/file-publication.ts
@@ -3,7 +3,7 @@ import { PulpAPI } from './pulp';
 
 /**
  * File Publication Type.
- * 
+ *
  * @see https://github.com/pulp/pulpcore/blob/934c752dae916857b2005e1fe0ef75496accc082/pulp_file/app/serializers.py#L200
  */
 interface FilePublicationType extends GenericPublication {

--- a/src/api/file-remote.ts
+++ b/src/api/file-remote.ts
@@ -1,34 +1,16 @@
+import type { GenericRemote } from './common';
 import { PulpAPI } from './pulp';
 
-export class FileRemoteType {
-  ca_cert: string;
-  client_cert: string;
-  download_concurrency: number;
-  name: string;
-  proxy_url: string;
-  pulp_href?: string;
-  rate_limit: number;
-  tls_validation: boolean;
-  url: string;
-  sync_dependencies?: boolean;
-
-  // connect_timeout
-  // headers
-  // max_retries
-  // policy
-  // prn
-  // pulp_created
-  // pulp_labels
-  // pulp_last_updated
-  // sock_connect_timeout
-  // sock_read_timeout
-  // total_timeout
-
-  hidden_fields: {
-    is_set: boolean;
-    name: string;
-  }[];
-
+/**
+ * File Remote Type.
+ *
+ * @see https://github.com/pulp/pulpcore/blob/934c752dae916857b2005e1fe0ef75496accc082/pulp_file/app/serializers.py#L165
+ */
+interface FileRemoteType extends GenericRemote {
+  /**
+   * NOTE: Not part of the Ansible serializer, populated separately.
+   * This should be broken out into its own type and extend the interface.
+   */
   my_permissions?: string[];
 }
 
@@ -62,3 +44,5 @@ export const FileRemoteAPI = {
   smartUpdate: (id, newValue: FileRemoteType, oldValue: FileRemoteType) =>
     base.http.put(`remotes/file/file/${id}/`, smartUpdate(newValue, oldValue)),
 };
+
+export type { FileRemoteType };

--- a/src/api/file-remote.ts
+++ b/src/api/file-remote.ts
@@ -8,7 +8,7 @@ import { PulpAPI } from './pulp';
  */
 interface FileRemoteType extends GenericRemote {
   /**
-   * NOTE: Not part of the Ansible serializer, populated separately.
+   * NOTE: Not part of the File serializer, populated separately.
    * This should be broken out into its own type and extend the interface.
    */
   my_permissions?: string[];

--- a/src/api/file-repository.ts
+++ b/src/api/file-repository.ts
@@ -3,7 +3,7 @@ import { PulpAPI } from './pulp';
 
 /**
  * Type for syncing metadata set on FileRepository after each sync.
- * @see https://github.com/pulp/pulpcore/blob/main/pulp_file/app/tasks/synchronizing.py
+ * @see https://github.com/pulp/pulpcore/blob/934c752dae916857b2005e1fe0ef75496accc082/pulp_file/app/tasks/synchronizing.py#L97
  */
 interface FileLastSyncDetailsType {
   remote_pk: string;
@@ -17,7 +17,7 @@ interface FileLastSyncDetailsType {
 /**
  * File Repository Type.
  *
- * @see https://github.com/pulp/pulpcore/blob/main/pulp_file/app/serializers.py
+ * @see https://github.com/pulp/pulpcore/blob/934c752dae916857b2005e1fe0ef75496accc082/pulp_file/app/serializers.py#L122
  */
 interface FileRepositoryType extends GenericRepository {
   autopublish?: boolean;

--- a/src/api/file-repository.ts
+++ b/src/api/file-repository.ts
@@ -1,19 +1,28 @@
+import type { GenericRepository } from './common';
 import { PulpAPI } from './pulp';
 
-export class FileRepositoryType {
+/**
+ * Type for syncing metadata set on FileRepository after each sync.
+ * @see https://github.com/pulp/pulpcore/blob/main/pulp_file/app/tasks/synchronizing.py
+ */
+interface FileLastSyncDetailsType {
+  remote_pk: string;
+  url: string;
+  download_policy: string;
+  mirror: boolean;
+  most_recent_version: number;
+  manifest_checksum: string;
+}
+
+/**
+ * File Repository Type.
+ *
+ * @see https://github.com/pulp/pulpcore/blob/main/pulp_file/app/serializers.py
+ */
+interface FileRepositoryType extends GenericRepository {
   autopublish?: boolean;
-  description: string | null;
-  latest_version_href?: string;
-  manifest?: string;
-  name: string;
-  prn?: string;
-  pulp_created?: string;
-  pulp_href?: string;
-  pulp_labels: Record<string, string>;
-  pulp_last_updated?: string;
-  remote: string | null;
-  retain_repo_versions: number;
-  versions_href?: string;
+  manifest?: string | null;
+  readonly last_sync_details?: FileLastSyncDetailsType | null;
 }
 
 const base = new PulpAPI();
@@ -39,3 +48,5 @@ export const FileRepositoryAPI = {
   update: (id: string, data) =>
     base.http.put(`repositories/file/file/${id}/`, data),
 };
+
+export type { FileRepositoryType };

--- a/src/api/response-types/remote.ts
+++ b/src/api/response-types/remote.ts
@@ -3,7 +3,7 @@ import { type PulpStatus } from './pulp';
 /**
  * @deprecated
  * Use `LastSyncType` from `common.ts` instead.
- * 
+ *
  * Known issue: `started_at` doesn't match real API field, and `finished_at` / `error` are actually nullable.
  */
 export class LastSyncType {

--- a/src/api/response-types/remote.ts
+++ b/src/api/response-types/remote.ts
@@ -1,5 +1,11 @@
 import { type PulpStatus } from './pulp';
 
+/**
+ * @deprecated
+ * Use `LastSyncType` from `common.ts` instead.
+ * 
+ * Known issue: `started_at` doesn't match real API field, and `finished_at` / `error` are actually nullable.
+ */
 export class LastSyncType {
   state: PulpStatus;
   started_at: string;

--- a/src/api/response-types/remote.ts
+++ b/src/api/response-types/remote.ts
@@ -1,11 +1,5 @@
 import { type PulpStatus } from './pulp';
 
-/**
- * @deprecated
- * Use `LastSyncType` from `common.ts` instead.
- *
- * Known issue: `started_at` doesn't match real API field, and `finished_at` / `error` are actually nullable.
- */
 export class LastSyncType {
   state: PulpStatus;
   started_at: string;

--- a/src/api/rpm-repository.ts
+++ b/src/api/rpm-repository.ts
@@ -1,13 +1,21 @@
 import type { GenericRepository } from './common';
 import { PulpAPI } from './pulp';
 
-type RPMChecksumType = "unknown" | "md5" | "sha" | "sha1" | "sha224" | "sha256" | "sha384" | "sha512";
-type RPMCompressionType = "zstd" | "gz" | "none";
-type RPMLayoutType = "nested_alphabetically" | "flat" | "nested_by_digest";
+type RPMChecksumType =
+  | 'unknown'
+  | 'md5'
+  | 'sha'
+  | 'sha1'
+  | 'sha224'
+  | 'sha256'
+  | 'sha384'
+  | 'sha512';
+type RPMCompressionType = 'zstd' | 'gz' | 'none';
+type RPMLayoutType = 'nested_alphabetically' | 'flat' | 'nested_by_digest';
 
 /**
  * RPM Repository Type.
- * 
+ *
  * @see https://github.com/pulp/pulp_rpm/blob/main/pulp_rpm/app/serializers/repository.py
  */
 interface RPMRepositoryType extends GenericRepository {

--- a/src/api/rpm-repository.ts
+++ b/src/api/rpm-repository.ts
@@ -1,7 +1,32 @@
+import type { GenericRepository } from './common';
 import { PulpAPI } from './pulp';
+
+type RPMChecksumType = "unknown" | "md5" | "sha" | "sha1" | "sha224" | "sha256" | "sha384" | "sha512";
+type RPMCompressionType = "zstd" | "gz" | "none";
+type RPMLayoutType = "nested_alphabetically" | "flat" | "nested_by_digest";
+
+/**
+ * RPM Repository Type.
+ * 
+ * @see https://github.com/pulp/pulp_rpm/blob/main/pulp_rpm/app/serializers/repository.py
+ */
+interface RPMRepositoryType extends GenericRepository {
+  autopublish?: boolean;
+  metadata_signing_service?: string | null;
+  package_signing_service?: string | null;
+  package_signing_fingerprint?: string | null;
+  retain_package_versions?: number;
+  checksum_type?: RPMChecksumType | null;
+  compression_type?: RPMCompressionType | null;
+  layout?: RPMLayoutType | null;
+  repo_config?: Record<string, unknown>;
+  osv_config?: { name: string; releases: unknown }[] | null;
+}
 
 const base = new PulpAPI();
 
 export const RPMRepositoryAPI = {
   list: (params?) => base.list(`repositories/rpm/rpm/`, params),
 };
+
+export type { RPMRepositoryType };


### PR DESCRIPTION
## Summary

Added shared base types in new `src/api/common.ts`, mapped against Pulp's core
serializer types (repository, remote, distribution, publication). Types only —
no behavioural or structural changes to existing API calls.

## Changes

1. Added `src/api/common.ts` with `GenericResource`, `GenericRepository`,
   `GenericRemote`, `GenericDistribution`, `GenericPublication` and shared
   plugin types.
2. Updated interfaces in related Ansible plugins to extend the new Generic
   types, correcting several field type mismatches.
3. Added types to RPM plugins, previously untyped.
4. Added types to File plugins, previously untyped.
5. Added Container Distribution types, previously untyped.

### Related

1. Issue - #255 
6. Pull Request - #254

### Sources

1. https://github.com/pulp/pulp_container/tree/main
7. https://github.com/pulp/pulp_ansible/tree/main
8. https://github.com/pulp/pulpcore/tree/main
9. https://github.com/pulp/pulp_rpm
