### PR TITLE
Added typed RPM Publication API Client

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,9 +94,11 @@
     "start": "NODE_ENV=development webpack serve --config config/start.config.js",
     "test": "true",
     "test:check-ts": "node -e \"process.versions.node.localeCompare('22.10.0',undefined,{numeric:true})>=0||(console.error('Testing uses feature flags requiring Node >= 22.10.0, but is using '+process.versions.node),process.exit(1))\"",
-    "test:unit": "npm run test:check-ts && node --test --experimental-strip-types --test-name-pattern '^Unit: '",
-    "test:integration": "npm run test:check-ts && node --test --experimental-strip-types --test-name-pattern '^Integration: '",
-    "test:coverage": "npm run test:check-ts && node --test --experimental-strip-types --experimental-test-coverage --test-coverage-exclude '**/*.test.ts' --test-coverage-exclude 'src/api/test-utils/**'",
+    "test:check-api-status": "curl -sf \"${PULP_BASE_URL:-http://localhost:8080/pulp/api/v3/}status/\" -o /dev/null || (echo 'Integration tests require the Pulp API, is it running?' >&2; exit 1)",
+    "test:check": "npm run test:check-ts && npm run test:check-api-status",
+    "test:unit": "npm run test:check && node --test --experimental-strip-types --test-name-pattern '^Unit: '",
+    "test:integration": "npm run test:check && node --test --experimental-strip-types --test-name-pattern '^Integration: '",
+    "test:coverage": "npm run test:check && node --test --experimental-strip-types --experimental-test-coverage --test-coverage-exclude '**/*.test.ts' --test-coverage-exclude 'src/api/test-utils/**'",
     "upgrade": "npx npm-check-updates -u -t minor"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "test:check-ts": "node -e \"process.versions.node.localeCompare('22.10.0',undefined,{numeric:true})>=0||(console.error('Testing uses feature flags requiring Node >= 22.10.0, but is using '+process.versions.node),process.exit(1))\"",
     "test:unit": "npm run test:check-ts && node --test --experimental-strip-types --test-name-pattern '^Unit: '",
     "test:integration": "npm run test:check-ts && node --test --experimental-strip-types --test-name-pattern '^Integration: '",
-    "test:coverage": "npm run test:check-ts && node --test --experimental-strip-types --experimental-test-coverage --test-coverage-exclude '**/*.test.ts'",
+    "test:coverage": "npm run test:check-ts && node --test --experimental-strip-types --experimental-test-coverage --test-coverage-exclude '**/*.test.ts' --test-coverage-exclude 'src/api/test-utils/**'",
     "upgrade": "npx npm-check-updates -u -t minor"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -93,6 +93,10 @@
     "sort-exports": "perl -i -pe 's/^export/import/' src/**/index.ts ; npm run prettier ; perl -i -pe 's/^import/export/' src/**/index.ts",
     "start": "NODE_ENV=development webpack serve --config config/start.config.js",
     "test": "true",
+    "test:check-ts": "node -e \"process.versions.node.localeCompare('22.10.0',undefined,{numeric:true})>=0||(console.error('Testing uses feature flags requiring Node >= 22.10.0, but is using '+process.versions.node),process.exit(1))\"",
+    "test:unit": "npm run test:check-ts && node --test --experimental-strip-types --test-name-pattern '^Unit: '",
+    "test:integration": "npm run test:check-ts && node --test --experimental-strip-types --test-name-pattern '^Integration: '",
+    "test:coverage": "npm run test:check-ts && node --test --experimental-strip-types --experimental-test-coverage --test-coverage-exclude '**/*.test.ts'",
     "upgrade": "npx npm-check-updates -u -t minor"
   },
   "engines": {

--- a/src/api/ansible-distribution.ts
+++ b/src/api/ansible-distribution.ts
@@ -3,10 +3,13 @@ import { PulpAPI } from './pulp';
 
 /**
  * Ansible Distribution Type.
- * 
+ *
  * @see https://github.com/pulp/pulp_ansible/blob/0043923641fc7fd3893f8489fd29ff04addc9d71/pulp_ansible/app/serializers.py#L356
  */
-interface AnsibleDistributionType extends Omit<GenericDistribution, 'base_url'> {
+interface AnsibleDistributionType extends Omit<
+  GenericDistribution,
+  'base_url'
+> {
   readonly client_url: string;
   repository_version?: string | null;
 }

--- a/src/api/ansible-distribution.ts
+++ b/src/api/ansible-distribution.ts
@@ -1,4 +1,15 @@
+import type { GenericDistribution } from './common';
 import { PulpAPI } from './pulp';
+
+/**
+ * Ansible Distribution Type.
+ * 
+ * @see https://github.com/pulp/pulp_ansible/blob/0043923641fc7fd3893f8489fd29ff04addc9d71/pulp_ansible/app/serializers.py#L356
+ */
+interface AnsibleDistributionType extends Omit<GenericDistribution, 'base_url'> {
+  readonly client_url: string;
+  repository_version?: string | null;
+}
 
 const base = new PulpAPI();
 
@@ -11,3 +22,5 @@ export const AnsibleDistributionAPI = {
 
   url: (distro_data) => distro_data.client_url,
 };
+
+export type { AnsibleDistributionType };

--- a/src/api/ansible-remote.ts
+++ b/src/api/ansible-remote.ts
@@ -1,6 +1,11 @@
 import type { AnsibleLastSyncType, GenericRemote } from './common';
 import { PulpAPI } from './pulp';
 
+/**
+ * Ansible Remote Type.
+ *
+ * @see https://github.com/pulp/pulp_ansible/blob/0043923641fc7fd3893f8489fd29ff04addc9d71/pulp_ansible/app/serializers.py#L213
+ */
 interface AnsibleRemoteType extends GenericRemote {
   requirements_file?: string | null;
   auth_url?: string | null;
@@ -9,7 +14,7 @@ interface AnsibleRemoteType extends GenericRemote {
   signed_only?: boolean;
   readonly last_sync_task?: AnsibleLastSyncType | null;
   /**
-   * NOTE: Not part of the Ansible serializer, populated separately. 
+   * NOTE: Not part of the Ansible serializer, populated separately.
    * This should be broken out into its own type and extend the interface.
    */
   my_permissions?: string[];
@@ -72,4 +77,4 @@ export const AnsibleRemoteAPI = {
     ),
 };
 
-export type { AnsibleRemoteType }
+export type { AnsibleRemoteType };

--- a/src/api/ansible-remote.ts
+++ b/src/api/ansible-remote.ts
@@ -1,36 +1,17 @@
+import type { AnsibleLastSyncType, GenericRemote } from './common';
 import { PulpAPI } from './pulp';
 
-export class AnsibleRemoteType {
-  auth_url: string;
-  ca_cert: string;
-  client_cert: string;
-  download_concurrency: number;
-  name: string;
-  proxy_url: string;
-  pulp_href?: string;
-  rate_limit: number;
-  requirements_file: string;
-  tls_validation: boolean;
-  url: string;
-  signed_only: boolean;
+interface AnsibleRemoteType extends GenericRemote {
+  requirements_file?: string | null;
+  auth_url?: string | null;
+  token?: string | null;
   sync_dependencies?: boolean;
-
-  // connect_timeout
-  // headers
-  // max_retries
-  // policy
-  // pulp_created
-  // pulp_labels
-  // pulp_last_updated
-  // sock_connect_timeout
-  // sock_read_timeout
-  // total_timeout
-
-  hidden_fields: {
-    is_set: boolean;
-    name: string;
-  }[];
-
+  signed_only?: boolean;
+  readonly last_sync_task?: AnsibleLastSyncType | null;
+  /**
+   * NOTE: Not part of the Ansible serializer, populated separately. 
+   * This should be broken out into its own type and extend the interface.
+   */
   my_permissions?: string[];
 }
 
@@ -90,3 +71,5 @@ export const AnsibleRemoteAPI = {
       smartUpdate(newValue, oldValue),
     ),
 };
+
+export type { AnsibleRemoteType }

--- a/src/api/ansible-repository.ts
+++ b/src/api/ansible-repository.ts
@@ -1,22 +1,17 @@
+import type { GenericRepository, LastSyncType } from './common';
 import { PulpAPI } from './pulp';
-import { type LastSyncType } from './response-types/remote';
 
-export class AnsibleRepositoryType {
-  description: string;
-  last_sync_task?: LastSyncType;
-  latest_version_href?: string;
-  name: string;
+/**
+ * Ansible Repository Type.
+ * 
+ * @see https://github.com/pulp/pulp_ansible/blob/main/pulp_ansible/app/serializers.py
+ */
+interface AnsibleRepositoryType extends GenericRepository {
+  last_synced_metadata_time?: string | null;
+  gpgkey?: string | null;
+  readonly last_sync_task?: LastSyncType;
   private?: boolean;
-  pulp_created?: string;
-  pulp_href?: string;
-  pulp_labels?: Record<string, string>;
-  remote?: string;
-  retain_repo_versions: number;
-
-  // gpgkey
-  // last_synced_metadata_time
-  // versions_href
-
+  // NOTE: Not part of the Ansible serializer, populated separately.
   my_permissions?: string[];
 }
 
@@ -91,3 +86,5 @@ export const AnsibleRepositoryAPI = {
   update: (id: string, data) =>
     base.http.put(`repositories/ansible/ansible/${id}/`, data),
 };
+
+export type { AnsibleRepositoryType }

--- a/src/api/ansible-repository.ts
+++ b/src/api/ansible-repository.ts
@@ -12,7 +12,7 @@ interface AnsibleRepositoryType extends GenericRepository {
   readonly last_sync_task?: AnsibleLastSyncType | null;
   private?: boolean;
   /**
-   * NOTE: Not part of the Ansible serializer, populated separately. 
+   * NOTE: Not part of the Ansible serializer, populated separately.
    * This should be broken out into its own type and extend the interface.
    */
   my_permissions?: string[];

--- a/src/api/ansible-repository.ts
+++ b/src/api/ansible-repository.ts
@@ -1,29 +1,15 @@
-import type { GenericRepository, TaskErrorType } from './common';
+import type { AnsibleLastSyncType, GenericRepository } from './common';
 import { PulpAPI } from './pulp';
-import type { PulpStatus } from './response-types/pulp';
-
-/**
- * Last Sync Task Type.
- *
- * @see https://github.com/pulp/pulp_ansible/blob/main/pulp_ansible/app/utils.py
- */
-interface LastSyncType {
-  pk: string;
-  state: PulpStatus;
-  pulp_created: string;
-  finished_at: string | null;
-  error: TaskErrorType | null;
-}
 
 /**
  * Ansible Repository Type.
  *
- * @see https://github.com/pulp/pulp_ansible/blob/main/pulp_ansible/app/serializers.py
+ * @see https://github.com/pulp/pulp_ansible/blob/0043923641fc7fd3893f8489fd29ff04addc9d71/pulp_ansible/app/serializers.py#L148
  */
 interface AnsibleRepositoryType extends GenericRepository {
   last_synced_metadata_time?: string | null;
   gpgkey?: string | null;
-  readonly last_sync_task?: LastSyncType | null;
+  readonly last_sync_task?: AnsibleLastSyncType | null;
   private?: boolean;
   /**
    * NOTE: Not part of the Ansible serializer, populated separately. 

--- a/src/api/ansible-repository.ts
+++ b/src/api/ansible-repository.ts
@@ -3,7 +3,7 @@ import { PulpAPI } from './pulp';
 
 /**
  * Ansible Repository Type.
- * 
+ *
  * @see https://github.com/pulp/pulp_ansible/blob/main/pulp_ansible/app/serializers.py
  */
 interface AnsibleRepositoryType extends GenericRepository {
@@ -87,4 +87,4 @@ export const AnsibleRepositoryAPI = {
     base.http.put(`repositories/ansible/ansible/${id}/`, data),
 };
 
-export type { AnsibleRepositoryType }
+export type { AnsibleRepositoryType };

--- a/src/api/ansible-repository.ts
+++ b/src/api/ansible-repository.ts
@@ -1,5 +1,19 @@
-import type { GenericRepository, LastSyncType } from './common';
+import type { GenericRepository, TaskErrorType } from './common';
 import { PulpAPI } from './pulp';
+import type { PulpStatus } from './response-types/pulp';
+
+/**
+ * Last Sync Task Type.
+ *
+ * @see https://github.com/pulp/pulp_ansible/blob/main/pulp_ansible/app/utils.py
+ */
+interface LastSyncType {
+  pk: string;
+  state: PulpStatus;
+  pulp_created: string;
+  finished_at: string | null;
+  error: TaskErrorType | null;
+}
 
 /**
  * Ansible Repository Type.
@@ -9,9 +23,12 @@ import { PulpAPI } from './pulp';
 interface AnsibleRepositoryType extends GenericRepository {
   last_synced_metadata_time?: string | null;
   gpgkey?: string | null;
-  readonly last_sync_task?: LastSyncType;
+  readonly last_sync_task?: LastSyncType | null;
   private?: boolean;
-  // NOTE: Not part of the Ansible serializer, populated separately.
+  /**
+   * NOTE: Not part of the Ansible serializer, populated separately. 
+   * This should be broken out into its own type and extend the interface.
+   */
   my_permissions?: string[];
 }
 

--- a/src/api/common.ts
+++ b/src/api/common.ts
@@ -16,14 +16,14 @@ interface GenericResource {
  * @see https://github.com/pulp/pulpcore/blob/main/pulpcore/app/serializers/repository.py
  */
 interface GenericRepository extends GenericResource {
-    readonly pulp_labels?: Record<string, string>;
+    pulp_labels?: Record<string, string>;
     readonly versions_href?: string;
     readonly latest_version_href?: string;
-    readonly name: string;
-    readonly description: string | null;
-    readonly retain_repo_versions: string | null;
-    readonly retain_checkpoints: string | null;
-    readonly remote: string | null;
+    name: string;
+    description?: string | null;
+    retain_repo_versions?: number | null;
+    retain_checkpoints?: number | null;
+    remote?: string | null;
 }
 
 export type { GenericRepository }

--- a/src/api/common.ts
+++ b/src/api/common.ts
@@ -179,7 +179,7 @@ interface GenericPaginatedResponse<TResult> {
   count: number;
   next: string | null;
   previous: string | null;
-  results: TResult;
+  results: TResult[];
 }
 
 /**

--- a/src/api/common.ts
+++ b/src/api/common.ts
@@ -1,3 +1,5 @@
+import type { PulpStatus } from "./response-types/pulp";
+
 /**
  * Generic PulpCore Exceptions based on dictionary representation.
  * @see https://github.com/pulp/pulpcore/blob/main/pulpcore/exceptions/base.py
@@ -64,4 +66,55 @@ interface GenericPublication extends GenericResource {
   repository?: string;
 }
 
-export type { TaskErrorType, GenericRepository, GenericDistribution, GenericPublication };
+/**
+ * Generic Remote shared across Pulp Remote plugins.
+ * 
+ * @see https://github.com/pulp/pulpcore/blob/934c752dae916857b2005e1fe0ef75496accc082/pulpcore/app/serializers/repository.py#L85
+ * @see https://github.com/pulp/pulpcore/blob/934c752dae916857b2005e1fe0ef75496accc082/pulpcore/app/serializers/base.py#L612
+ * @see https://github.com/pulp/pulpcore/blob/934c752dae916857b2005e1fe0ef75496accc082/pulpcore/app/serializers/base.py#L367
+ */
+interface GenericRemote extends GenericResource {
+  pulp_labels?: Record<string, string>;
+  name: string;
+  url: string;
+  policy?: string;
+  readonly hidden_fields?: { name: string; is_set: boolean; }[];
+  ca_cert?: string | null;
+  client_cert?: string | null;
+  client_key?: string | null;
+  tls_validation?: boolean;
+  proxy_url?: string | null;
+  proxy_username?: string | null;
+  proxy_password?: string | null;
+  username?: string | null;
+  password?: string | null;
+  max_retries?: number | null;
+  total_timeout?: number | null;
+  connect_timeout?: number | null;
+  sock_connect_timeout?: number | null;
+  sock_read_timeout?: number | null;
+  headers?: unknown[];
+  download_concurrency?: number | null;
+  rate_limit?: number | null;
+}
+
+/**
+ * --------------------
+ * These are shared Plugin Types outside the PulpCore Generics.
+ * --------------------
+ */
+
+/**
+ * Last Sync Task Type.
+ *
+ * @see https://github.com/pulp/pulp_ansible/blob/main/pulp_ansible/app/utils.py
+ */
+interface AnsibleLastSyncType {
+  pk: string;
+  state: PulpStatus;
+  pulp_created: string;
+  finished_at: string | null;
+  error: TaskErrorType | null;
+}
+
+export type { TaskErrorType, GenericRepository, GenericDistribution, GenericPublication, GenericRemote, AnsibleLastSyncType };

--- a/src/api/common.ts
+++ b/src/api/common.ts
@@ -1,0 +1,29 @@
+/**
+ * Generic Resource shared across every Pulp resource.
+ * 
+ * @see https://github.com/pulp/pulpcore/blob/main/pulpcore/app/serializers/base.py
+ */
+interface GenericResource {
+    readonly pulp_href?: string;
+    readonly prn?: string;
+    readonly pulp_created?: string;
+    readonly pulp_last_updated?: string;
+}
+
+/**
+ * Generic Repository shared across Pulp Repository plugins.
+ * 
+ * @see https://github.com/pulp/pulpcore/blob/main/pulpcore/app/serializers/repository.py
+ */
+interface GenericRepository extends GenericResource {
+    readonly pulp_labels?: Record<string, string>;
+    readonly versions_href?: string;
+    readonly latest_version_href?: string;
+    readonly name: string;
+    readonly description: string | null;
+    readonly retain_repo_versions: string | null;
+    readonly retain_checkpoints: string | null;
+    readonly remote: string | null;
+}
+
+export type { GenericRepository }

--- a/src/api/common.ts
+++ b/src/api/common.ts
@@ -1,5 +1,3 @@
-import type { PulpStatus } from './response-types/pulp';
-
 /**
  * Generic PulpCore Exceptions based on dictionary representation.
  * @see https://github.com/pulp/pulpcore/blob/main/pulpcore/exceptions/base.py
@@ -38,23 +36,4 @@ interface GenericRepository extends GenericResource {
   remote?: string | null;
 }
 
-/**
- * --------------------
- * Shared types reused across multiple resource types but not part of pulpcore generic types.
- * --------------------
- */
-
-/**
- * Last Sync Task Type.
- *
- * @see https://github.com/pulp/pulp_ansible/blob/main/pulp_ansible/app/utils.py
- */
-interface LastSyncType {
-  pk: string;
-  state: PulpStatus;
-  pulp_created: string;
-  finished_at: string;
-  error: TaskErrorType;
-}
-
-export type { TaskErrorType, GenericRepository, LastSyncType };
+export type { TaskErrorType, GenericRepository };

--- a/src/api/common.ts
+++ b/src/api/common.ts
@@ -1,3 +1,15 @@
+import type { PulpStatus } from "./response-types/pulp";
+
+/**
+ * Generic PulpCore Exceptions based on dictionary representation.
+ * @see https://github.com/pulp/pulpcore/blob/main/pulpcore/exceptions/base.py
+ */
+interface TaskErrorType {
+    description: string;
+    traceback: string | null;
+    error_code?: string;
+}
+
 /**
  * Generic Resource shared across every Pulp resource.
  * 
@@ -26,4 +38,23 @@ interface GenericRepository extends GenericResource {
     remote?: string | null;
 }
 
-export type { GenericRepository }
+/**
+ * --------------------
+ * Shared types reused across multiple resource types but not part of pulpcore generic types.
+ * --------------------
+ */
+
+/**
+ * Last Sync Task Type.
+ * 
+ * @see https://github.com/pulp/pulp_ansible/blob/main/pulp_ansible/app/utils.py
+ */
+interface LastSyncType {
+    pk: string;
+    state: PulpStatus;
+    pulp_created: string;
+    finished_at: string;
+    error: TaskErrorType;
+}
+
+export type { TaskErrorType, GenericRepository, LastSyncType }

--- a/src/api/common.ts
+++ b/src/api/common.ts
@@ -237,6 +237,24 @@ interface GenericDistributionFilterParams
   with_content?: string;
 }
 
+type PulpCreatedPublicationFilterParams = LookupFilterParams<
+  'pulp_created',
+  DateTimeFilterOptions,
+  string
+>;
+
+/**
+ * Generic Publication Filters shared across PulpCore & Plugin Endpoints.
+ */
+interface GenericPublicationFilterParams
+  extends GenericFilterParams, PulpCreatedPublicationFilterParams {
+  repository?: string;
+  respository_version?: string;
+  content?: string;
+  content__in?: string;
+  checkpoint?: boolean;
+}
+
 /**
  * --------------------
  * These are shared Plugin Types outside the PulpCore Generics.
@@ -267,5 +285,6 @@ export type {
   DispatchedTaskResponse,
   GenericRemoteFilterParams,
   GenericDistributionFilterParams,
+  GenericPublicationFilterParams,
   AnsibleLastSyncType,
 };

--- a/src/api/common.ts
+++ b/src/api/common.ts
@@ -1,41 +1,41 @@
-import type { PulpStatus } from "./response-types/pulp";
+import type { PulpStatus } from './response-types/pulp';
 
 /**
  * Generic PulpCore Exceptions based on dictionary representation.
  * @see https://github.com/pulp/pulpcore/blob/main/pulpcore/exceptions/base.py
  */
 interface TaskErrorType {
-    description: string;
-    traceback: string | null;
-    error_code?: string;
+  description: string;
+  traceback: string | null;
+  error_code?: string;
 }
 
 /**
  * Generic Resource shared across every Pulp resource.
- * 
+ *
  * @see https://github.com/pulp/pulpcore/blob/main/pulpcore/app/serializers/base.py
  */
 interface GenericResource {
-    readonly pulp_href?: string;
-    readonly prn?: string;
-    readonly pulp_created?: string;
-    readonly pulp_last_updated?: string;
+  readonly pulp_href?: string;
+  readonly prn?: string;
+  readonly pulp_created?: string;
+  readonly pulp_last_updated?: string;
 }
 
 /**
  * Generic Repository shared across Pulp Repository plugins.
- * 
+ *
  * @see https://github.com/pulp/pulpcore/blob/main/pulpcore/app/serializers/repository.py
  */
 interface GenericRepository extends GenericResource {
-    pulp_labels?: Record<string, string>;
-    readonly versions_href?: string;
-    readonly latest_version_href?: string;
-    name: string;
-    description?: string | null;
-    retain_repo_versions?: number | null;
-    retain_checkpoints?: number | null;
-    remote?: string | null;
+  pulp_labels?: Record<string, string>;
+  readonly versions_href?: string;
+  readonly latest_version_href?: string;
+  name: string;
+  description?: string | null;
+  retain_repo_versions?: number | null;
+  retain_checkpoints?: number | null;
+  remote?: string | null;
 }
 
 /**
@@ -46,15 +46,15 @@ interface GenericRepository extends GenericResource {
 
 /**
  * Last Sync Task Type.
- * 
+ *
  * @see https://github.com/pulp/pulp_ansible/blob/main/pulp_ansible/app/utils.py
  */
 interface LastSyncType {
-    pk: string;
-    state: PulpStatus;
-    pulp_created: string;
-    finished_at: string;
-    error: TaskErrorType;
+  pk: string;
+  state: PulpStatus;
+  pulp_created: string;
+  finished_at: string;
+  error: TaskErrorType;
 }
 
-export type { TaskErrorType, GenericRepository, LastSyncType }
+export type { TaskErrorType, GenericRepository, LastSyncType };

--- a/src/api/common.ts
+++ b/src/api/common.ts
@@ -154,7 +154,7 @@ type RetainCheckpointsFilterParams = LookupFilterParams<
 
 /**
  * Generic Repository Filters shared across PulpCore & Plugin Endpoints.
- * 
+ *
  * @see https://github.com/pulp/pulpcore/blob/934c752dae916857b2005e1fe0ef75496accc082/pulpcore/app/viewsets/repository.py#L88
  */
 interface GenericRepositoryFilterParams
@@ -170,16 +170,25 @@ interface GenericRepositoryFilterParams
 }
 
 /**
- * Generic Paginated Response shared across PulpCore & Plugin Endpoints.
- * 
+ * Paginated Response shared across PulpCore & Plugin Endpoints.
+ *
  * @see https://github.com/pulp/pulpcore/blob/934c752dae916857b2005e1fe0ef75496accc082/pulpcore/app/settings.py#L186
  * @see https://github.com/encode/django-rest-framework/blob/6f0b74def3fcc81e126b87b08e59abdb6c2ad056/rest_framework/pagination.py#L364
  */
-interface GenericPaginatedResponse<TResult> {
+interface PaginatedResponse<TResult> {
   count: number;
   next: string | null;
   previous: string | null;
   results: TResult[];
+}
+
+/**
+ * Async Task Dispatch Response shared across PulpCore & Plugin Endpoints.
+ *
+ * @see https://github.com/pulp/pulpcore/blob/dea04fa79a6ca590f2943a0a7754c219061be10c/pulpcore/app/response.py#L6
+ */
+interface DispatchedTaskResponse {
+  task: string;
 }
 
 /**
@@ -208,6 +217,7 @@ export type {
   GenericPublication,
   GenericRemote,
   GenericRepositoryFilterParams,
-  GenericPaginatedResponse,
+  PaginatedResponse,
+  DispatchedTaskResponse,
   AnsibleLastSyncType,
 };

--- a/src/api/common.ts
+++ b/src/api/common.ts
@@ -191,15 +191,20 @@ interface DispatchedTaskResponse {
   task: string;
 }
 
-type DateTimeFilterOptions = "lt" | "lte" | "gt" | "gte" | "range" | "isnull"
-type DateTimeFilterParams = LookupFilterParams<"pulp_last_updated", DateTimeFilterOptions, 'string'>
+type DateTimeFilterOptions = 'lt' | 'lte' | 'gt' | 'gte' | 'range' | 'isnull';
+type DateTimeFilterParams = LookupFilterParams<
+  'pulp_last_updated',
+  DateTimeFilterOptions,
+  'string'
+>;
 
 /**
  * Generic Remote Filters shared across PulpCore & Plugin Endpoints.
- * 
+ *
  * @see https://github.com/pulp/pulpcore/blob/934c752dae916857b2005e1fe0ef75496accc082/pulpcore/app/viewsets/repository.py#L314
  */
-interface GenericRemoteFilterParams extends GenericFilterParams, NameFilterParams, DateTimeFilterParams {
+interface GenericRemoteFilterParams
+  extends GenericFilterParams, NameFilterParams, DateTimeFilterParams {
   pulp_label_select?: string;
 }
 

--- a/src/api/common.ts
+++ b/src/api/common.ts
@@ -191,6 +191,18 @@ interface DispatchedTaskResponse {
   task: string;
 }
 
+type DateTimeFilterOptions = "lt" | "lte" | "gt" | "gte" | "range" | "isnull"
+type DateTimeFilterParams = LookupFilterParams<"pulp_last_updated", DateTimeFilterOptions, 'string'>
+
+/**
+ * Generic Remote Filters shared across PulpCore & Plugin Endpoints.
+ * 
+ * @see https://github.com/pulp/pulpcore/blob/934c752dae916857b2005e1fe0ef75496accc082/pulpcore/app/viewsets/repository.py#L314
+ */
+interface GenericRemoteFilterParams extends GenericFilterParams, NameFilterParams, DateTimeFilterParams {
+  pulp_label_select?: string;
+}
+
 /**
  * --------------------
  * These are shared Plugin Types outside the PulpCore Generics.
@@ -219,5 +231,6 @@ export type {
   GenericRepositoryFilterParams,
   PaginatedResponse,
   DispatchedTaskResponse,
+  GenericRemoteFilterParams,
   AnsibleLastSyncType,
 };

--- a/src/api/common.ts
+++ b/src/api/common.ts
@@ -1,8 +1,8 @@
-import type { PulpStatus } from "./response-types/pulp";
+import type { PulpStatus } from './response-types/pulp';
 
 /**
  * Generic PulpCore Exceptions based on dictionary representation.
- * @see https://github.com/pulp/pulpcore/blob/main/pulpcore/exceptions/base.py
+ * @see https://github.com/pulp/pulpcore/blob/934c752dae916857b2005e1fe0ef75496accc082/pulpcore/exceptions/base.py#L37
  */
 interface TaskErrorType {
   description: string;
@@ -25,7 +25,7 @@ interface GenericResource {
 /**
  * Generic Repository shared across Pulp Repository plugins.
  *
- * @see https://github.com/pulp/pulpcore/blob/main/pulpcore/app/serializers/repository.py
+ * @see https://github.com/pulp/pulpcore/blob/934c752dae916857b2005e1fe0ef75496accc082/pulpcore/app/serializers/repository.py#L26
  */
 interface GenericRepository extends GenericResource {
   pulp_labels?: Record<string, string>;
@@ -40,7 +40,7 @@ interface GenericRepository extends GenericResource {
 
 /**
  * Generic Distribution shared across Pulp Distribution plugins.
- * 
+ *
  * @see https://github.com/pulp/pulpcore/blob/934c752dae916857b2005e1fe0ef75496accc082/pulpcore/app/serializers/publication.py
  */
 interface GenericDistribution extends GenericResource {
@@ -58,7 +58,7 @@ interface GenericDistribution extends GenericResource {
 
 /**
  * Generic Publication shared across Pulp Publication plugins.
- * 
+ *
  * @see https://github.com/pulp/pulpcore/blob/934c752dae916857b2005e1fe0ef75496accc082/pulpcore/app/serializers/publication.py#L23
  */
 interface GenericPublication extends GenericResource {
@@ -68,7 +68,7 @@ interface GenericPublication extends GenericResource {
 
 /**
  * Generic Remote shared across Pulp Remote plugins.
- * 
+ *
  * @see https://github.com/pulp/pulpcore/blob/934c752dae916857b2005e1fe0ef75496accc082/pulpcore/app/serializers/repository.py#L85
  * @see https://github.com/pulp/pulpcore/blob/934c752dae916857b2005e1fe0ef75496accc082/pulpcore/app/serializers/base.py#L612
  * @see https://github.com/pulp/pulpcore/blob/934c752dae916857b2005e1fe0ef75496accc082/pulpcore/app/serializers/base.py#L367
@@ -78,7 +78,7 @@ interface GenericRemote extends GenericResource {
   name: string;
   url: string;
   policy?: string;
-  readonly hidden_fields?: { name: string; is_set: boolean; }[];
+  readonly hidden_fields?: { name: string; is_set: boolean }[];
   ca_cert?: string | null;
   client_cert?: string | null;
   client_key?: string | null;
@@ -107,7 +107,7 @@ interface GenericRemote extends GenericResource {
 /**
  * Last Sync Task Type.
  *
- * @see https://github.com/pulp/pulp_ansible/blob/main/pulp_ansible/app/utils.py
+ * @see https://github.com/pulp/pulp_ansible/blob/0043923641fc7fd3893f8489fd29ff04addc9d71/pulp_ansible/app/utils.py#L47
  */
 interface AnsibleLastSyncType {
   pk: string;
@@ -117,4 +117,11 @@ interface AnsibleLastSyncType {
   error: TaskErrorType | null;
 }
 
-export type { TaskErrorType, GenericRepository, GenericDistribution, GenericPublication, GenericRemote, AnsibleLastSyncType };
+export type {
+  TaskErrorType,
+  GenericRepository,
+  GenericDistribution,
+  GenericPublication,
+  GenericRemote,
+  AnsibleLastSyncType,
+};

--- a/src/api/common.ts
+++ b/src/api/common.ts
@@ -54,4 +54,14 @@ interface GenericDistribution extends GenericResource {
   repository_version?: string;
 }
 
-export type { TaskErrorType, GenericRepository, GenericDistribution };
+/**
+ * Generic Publication shared across Pulp Publication plugins.
+ * 
+ * @see https://github.com/pulp/pulpcore/blob/934c752dae916857b2005e1fe0ef75496accc082/pulpcore/app/serializers/publication.py#L23
+ */
+interface GenericPublication extends GenericResource {
+  repository_version?: string;
+  repository?: string;
+}
+
+export type { TaskErrorType, GenericRepository, GenericDistribution, GenericPublication };

--- a/src/api/common.ts
+++ b/src/api/common.ts
@@ -208,6 +208,35 @@ interface GenericRemoteFilterParams
   pulp_label_select?: string;
 }
 
+type BasePathFilterOptions = 'contains' | 'icontains' | 'in';
+type BasePathFilterParams = LookupFilterParams<
+  'base_path',
+  BasePathFilterOptions,
+  string
+>;
+type RepositoryFilterOptions = 'in';
+type RepositoryFilterParams = LookupFilterParams<
+  'repository',
+  RepositoryFilterOptions,
+  string
+>;
+
+/**
+ * Generic Distribution Filters shared across PulpCore & Plugin Endpoints.
+ *
+ * @see https://github.com/pulp/pulpcore/blob/934c752dae916857b2005e1fe0ef75496accc082/pulpcore/app/viewsets/publication.py#L486
+ */
+interface GenericDistributionFilterParams
+  extends
+    GenericFilterParams,
+    NameFilterParams,
+    BasePathFilterParams,
+    RepositoryFilterParams {
+  pulp_label_select?: string;
+  checkpoint?: boolean;
+  with_content?: string;
+}
+
 /**
  * --------------------
  * These are shared Plugin Types outside the PulpCore Generics.
@@ -237,5 +266,6 @@ export type {
   PaginatedResponse,
   DispatchedTaskResponse,
   GenericRemoteFilterParams,
+  GenericDistributionFilterParams,
   AnsibleLastSyncType,
 };

--- a/src/api/common.ts
+++ b/src/api/common.ts
@@ -41,7 +41,7 @@ interface GenericRepository extends GenericResource {
 /**
  * Generic Distribution shared across Pulp Distribution plugins.
  *
- * @see https://github.com/pulp/pulpcore/blob/934c752dae916857b2005e1fe0ef75496accc082/pulpcore/app/serializers/publication.py
+ * @see https://github.com/pulp/pulpcore/blob/934c752dae916857b2005e1fe0ef75496accc082/pulpcore/app/serializers/publication.py#L175
  */
 interface GenericDistribution extends GenericResource {
   base_path: string;

--- a/src/api/common.ts
+++ b/src/api/common.ts
@@ -195,7 +195,7 @@ type DateTimeFilterOptions = 'lt' | 'lte' | 'gt' | 'gte' | 'range' | 'isnull';
 type DateTimeFilterParams = LookupFilterParams<
   'pulp_last_updated',
   DateTimeFilterOptions,
-  'string'
+  string
 >;
 
 /**

--- a/src/api/common.ts
+++ b/src/api/common.ts
@@ -99,6 +99,90 @@ interface GenericRemote extends GenericResource {
 }
 
 /**
+ * Generic Filters shared across PulpCore & Plugin Endpoints.
+ *
+ * @see https://github.com/pulp/pulpcore/blob/934c752dae916857b2005e1fe0ef75496accc082/pulpcore/filters.py#L290
+ */
+interface GenericFilterParams {
+  pulp_id__in?: string;
+  pulp_href__in?: string;
+  prn__in?: string;
+  q?: string;
+  exclude_fields?: string;
+  fields?: string;
+  limit?: number;
+  minimal?: boolean;
+  offset?: number;
+  page_size?: number;
+  ordering?: string;
+  format?: string;
+}
+
+type LookupFilterParams<
+  Field extends string,
+  Lookup extends string,
+  Value,
+> = Partial<Record<Field | `${Field}__${Lookup}`, Value>>;
+type NameFilterOptions =
+  | 'iexact'
+  | 'in'
+  | 'contains'
+  | 'icontains'
+  | 'startswith'
+  | 'istartswith'
+  | 'regex'
+  | 'iregex';
+type NullableNumericFilterOptions =
+  | 'ne'
+  | 'lt'
+  | 'lte'
+  | 'gt'
+  | 'gte'
+  | 'range'
+  | 'isnull';
+type NameFilterParams = LookupFilterParams<'name', NameFilterOptions, string>;
+type RetainRepoVersionsFilterParams = LookupFilterParams<
+  'retain_repo_versions',
+  NullableNumericFilterOptions,
+  number | string
+>;
+type RetainCheckpointsFilterParams = LookupFilterParams<
+  'retain_checkpoints',
+  NullableNumericFilterOptions,
+  number | string
+>;
+
+/**
+ * Generic Repository Filters shared across PulpCore & Plugin Endpoints.
+ * 
+ * @see https://github.com/pulp/pulpcore/blob/934c752dae916857b2005e1fe0ef75496accc082/pulpcore/app/viewsets/repository.py#L88
+ */
+interface GenericRepositoryFilterParams
+  extends
+    GenericFilterParams,
+    NameFilterParams,
+    RetainRepoVersionsFilterParams,
+    RetainCheckpointsFilterParams {
+  pulp_label_select?: string;
+  remote?: string | null;
+  with_content?: string;
+  latest_with_content?: string;
+}
+
+/**
+ * Generic Paginated Response shared across PulpCore & Plugin Endpoints.
+ * 
+ * @see https://github.com/pulp/pulpcore/blob/934c752dae916857b2005e1fe0ef75496accc082/pulpcore/app/settings.py#L186
+ * @see https://github.com/encode/django-rest-framework/blob/6f0b74def3fcc81e126b87b08e59abdb6c2ad056/rest_framework/pagination.py#L364
+ */
+interface GenericPaginatedResponse<TResult> {
+  count: number;
+  next: string | null;
+  previous: string | null;
+  results: TResult;
+}
+
+/**
  * --------------------
  * These are shared Plugin Types outside the PulpCore Generics.
  * --------------------
@@ -123,5 +207,7 @@ export type {
   GenericDistribution,
   GenericPublication,
   GenericRemote,
+  GenericRepositoryFilterParams,
+  GenericPaginatedResponse,
   AnsibleLastSyncType,
 };

--- a/src/api/common.ts
+++ b/src/api/common.ts
@@ -11,7 +11,7 @@ interface TaskErrorType {
 /**
  * Generic Resource shared across every Pulp resource.
  *
- * @see https://github.com/pulp/pulpcore/blob/main/pulpcore/app/serializers/base.py
+ * @see https://github.com/pulp/pulpcore/blob/934c752dae916857b2005e1fe0ef75496accc082/pulpcore/app/serializers/base.py#L448
  */
 interface GenericResource {
   readonly pulp_href?: string;
@@ -36,4 +36,22 @@ interface GenericRepository extends GenericResource {
   remote?: string | null;
 }
 
-export type { TaskErrorType, GenericRepository };
+/**
+ * Generic Distribution shared across Pulp Distribution plugins.
+ * 
+ * @see https://github.com/pulp/pulpcore/blob/934c752dae916857b2005e1fe0ef75496accc082/pulpcore/app/serializers/publication.py
+ */
+interface GenericDistribution extends GenericResource {
+  base_path: string;
+  readonly base_url?: string;
+  content_guard?: string | null;
+  readonly content_guard_prn?: string | null;
+  readonly no_content_change_since?: string | null;
+  hidden?: boolean;
+  pulp_labels?: Record<string, string>;
+  name: string;
+  repository?: string;
+  repository_version?: string;
+}
+
+export type { TaskErrorType, GenericRepository, GenericDistribution };

--- a/src/api/container-distribution.ts
+++ b/src/api/container-distribution.ts
@@ -1,4 +1,42 @@
+import type { GenericDistribution } from './common';
 import { PulpAPI } from './pulp';
+
+/**
+ * Container Distribution Type.
+ *
+ * @see https://github.com/pulp/pulp_container/blob/b109af03cb7aae3431f7a73204e6a73a8457694c/pulp_container/app/serializers.py#L424
+ */
+interface ContainerDistributionType extends Omit<
+  GenericDistribution,
+  'base_url'
+> {
+  readonly registry_path: string;
+  content_guard?: string;
+  readonly namespace?: string;
+  description?: string | null;
+  repository_version?: string | null;
+  readonly remote?: string;
+  private?: boolean;
+  readonly pulp_domain?: string;
+}
+
+/**
+ * Container Pull Through Type.
+ *
+ * @see https://github.com/pulp/pulp_container/blob/b109af03cb7aae3431f7a73204e6a73a8457694c/pulp_container/app/serializers.py#L520
+ */
+interface ContainerPullThroughDistributionType extends Omit<
+  GenericDistribution,
+  'base_url'
+> {
+  remote: string;
+  readonly namespace?: string;
+  content_guard?: string;
+  distributions?: string[];
+  description?: string | null;
+  private?: boolean;
+  readonly pulp_domain?: string;
+}
 
 const base = new PulpAPI();
 
@@ -17,3 +55,5 @@ export const ContainerPullThroughDistributionAPI = {
   // We should probably put this into a field on the serializer
   url: (distro_data) => `${window.location.host}/${distro_data.base_path}/`,
 };
+
+export type { ContainerDistributionType, ContainerPullThroughDistributionType };

--- a/src/api/file-distribution.ts
+++ b/src/api/file-distribution.ts
@@ -1,4 +1,15 @@
+import type { GenericDistribution } from './common';
 import { PulpAPI } from './pulp';
+
+/**
+ * File Distribution Type.
+ * 
+ * @see https://github.com/pulp/pulpcore/blob/934c752dae916857b2005e1fe0ef75496accc082/pulp_file/app/serializers.py#L225
+ */
+interface FileDistributionType extends GenericDistribution {
+  publication?: string | null;
+  checkpoint?: boolean;
+}
 
 const base = new PulpAPI();
 
@@ -9,3 +20,5 @@ export const FileDistributionAPI = {
 
   list: (params?) => base.list(`distributions/file/file/`, params),
 };
+
+export type { FileDistributionType }

--- a/src/api/file-distribution.ts
+++ b/src/api/file-distribution.ts
@@ -3,7 +3,7 @@ import { PulpAPI } from './pulp';
 
 /**
  * File Distribution Type.
- * 
+ *
  * @see https://github.com/pulp/pulpcore/blob/934c752dae916857b2005e1fe0ef75496accc082/pulp_file/app/serializers.py#L225
  */
 interface FileDistributionType extends GenericDistribution {
@@ -21,4 +21,4 @@ export const FileDistributionAPI = {
   list: (params?) => base.list(`distributions/file/file/`, params),
 };
 
-export type { FileDistributionType }
+export type { FileDistributionType };

--- a/src/api/file-publication.ts
+++ b/src/api/file-publication.ts
@@ -1,4 +1,16 @@
+import type { GenericPublication } from './common';
 import { PulpAPI } from './pulp';
+
+/**
+ * File Publication Type.
+ * 
+ * @see https://github.com/pulp/pulpcore/blob/934c752dae916857b2005e1fe0ef75496accc082/pulp_file/app/serializers.py#L200
+ */
+interface FilePublicationType extends GenericPublication {
+  readonly distributions: string[];
+  manifest?: string | null;
+  checkpoint?: boolean;
+}
 
 const base = new PulpAPI();
 
@@ -9,3 +21,5 @@ export const FilePublicationAPI = {
 
   list: (params?) => base.list(`publications/file/file/`, params),
 };
+
+export type { FilePublicationType };

--- a/src/api/file-publication.ts
+++ b/src/api/file-publication.ts
@@ -3,7 +3,7 @@ import { PulpAPI } from './pulp';
 
 /**
  * File Publication Type.
- * 
+ *
  * @see https://github.com/pulp/pulpcore/blob/934c752dae916857b2005e1fe0ef75496accc082/pulp_file/app/serializers.py#L200
  */
 interface FilePublicationType extends GenericPublication {

--- a/src/api/file-remote.ts
+++ b/src/api/file-remote.ts
@@ -1,34 +1,16 @@
+import type { GenericRemote } from './common';
 import { PulpAPI } from './pulp';
 
-export class FileRemoteType {
-  ca_cert: string;
-  client_cert: string;
-  download_concurrency: number;
-  name: string;
-  proxy_url: string;
-  pulp_href?: string;
-  rate_limit: number;
-  tls_validation: boolean;
-  url: string;
-  sync_dependencies?: boolean;
-
-  // connect_timeout
-  // headers
-  // max_retries
-  // policy
-  // prn
-  // pulp_created
-  // pulp_labels
-  // pulp_last_updated
-  // sock_connect_timeout
-  // sock_read_timeout
-  // total_timeout
-
-  hidden_fields: {
-    is_set: boolean;
-    name: string;
-  }[];
-
+/**
+ * File Remote Type.
+ *
+ * @see https://github.com/pulp/pulpcore/blob/934c752dae916857b2005e1fe0ef75496accc082/pulp_file/app/serializers.py#L165
+ */
+interface FileRemoteType extends GenericRemote {
+  /**
+   * NOTE: Not part of the Ansible serializer, populated separately.
+   * This should be broken out into its own type and extend the interface.
+   */
   my_permissions?: string[];
 }
 
@@ -62,3 +44,5 @@ export const FileRemoteAPI = {
   smartUpdate: (id, newValue: FileRemoteType, oldValue: FileRemoteType) =>
     base.http.put(`remotes/file/file/${id}/`, smartUpdate(newValue, oldValue)),
 };
+
+export type { FileRemoteType };

--- a/src/api/file-remote.ts
+++ b/src/api/file-remote.ts
@@ -8,7 +8,7 @@ import { PulpAPI } from './pulp';
  */
 interface FileRemoteType extends GenericRemote {
   /**
-   * NOTE: Not part of the Ansible serializer, populated separately.
+   * NOTE: Not part of the File serializer, populated separately.
    * This should be broken out into its own type and extend the interface.
    */
   my_permissions?: string[];

--- a/src/api/file-repository.ts
+++ b/src/api/file-repository.ts
@@ -3,7 +3,7 @@ import { PulpAPI } from './pulp';
 
 /**
  * Type for syncing metadata set on FileRepository after each sync.
- * @see https://github.com/pulp/pulpcore/blob/main/pulp_file/app/tasks/synchronizing.py
+ * @see https://github.com/pulp/pulpcore/blob/934c752dae916857b2005e1fe0ef75496accc082/pulp_file/app/tasks/synchronizing.py#L97
  */
 interface FileLastSyncDetailsType {
   remote_pk: string;
@@ -17,7 +17,7 @@ interface FileLastSyncDetailsType {
 /**
  * File Repository Type.
  *
- * @see https://github.com/pulp/pulpcore/blob/main/pulp_file/app/serializers.py
+ * @see https://github.com/pulp/pulpcore/blob/934c752dae916857b2005e1fe0ef75496accc082/pulp_file/app/serializers.py#L122
  */
 interface FileRepositoryType extends GenericRepository {
   autopublish?: boolean;

--- a/src/api/file-repository.ts
+++ b/src/api/file-repository.ts
@@ -1,19 +1,28 @@
+import type { GenericRepository } from './common';
 import { PulpAPI } from './pulp';
 
-export class FileRepositoryType {
+/**
+ * Type for syncing metadata set on FileRepository after each sync.
+ * @see https://github.com/pulp/pulpcore/blob/main/pulp_file/app/tasks/synchronizing.py
+ */
+interface FileLastSyncDetailsType {
+  remote_pk: string;
+  url: string;
+  download_policy: string;
+  mirror: boolean;
+  most_recent_version: number;
+  manifest_checksum: string;
+}
+
+/**
+ * File Repository Type.
+ *
+ * @see https://github.com/pulp/pulpcore/blob/main/pulp_file/app/serializers.py
+ */
+interface FileRepositoryType extends GenericRepository {
   autopublish?: boolean;
-  description: string | null;
-  latest_version_href?: string;
-  manifest?: string;
-  name: string;
-  prn?: string;
-  pulp_created?: string;
-  pulp_href?: string;
-  pulp_labels: Record<string, string>;
-  pulp_last_updated?: string;
-  remote: string | null;
-  retain_repo_versions: number;
-  versions_href?: string;
+  manifest?: string | null;
+  readonly last_sync_details?: FileLastSyncDetailsType | null;
 }
 
 const base = new PulpAPI();
@@ -39,3 +48,5 @@ export const FileRepositoryAPI = {
   update: (id: string, data) =>
     base.http.put(`repositories/file/file/${id}/`, data),
 };
+
+export type { FileRepositoryType };

--- a/src/api/plugins/rpm/client.ts
+++ b/src/api/plugins/rpm/client.ts
@@ -1,8 +1,8 @@
 import { PulpAPI } from 'src/api/pulp';
 import { createDistributionAPI } from './distribution';
+import { createPublicationAPI } from './publication';
 import { createRemoteAPI } from './remote';
 import { createRepositoryAPI } from './repository';
-import { createPublicationAPI } from './publication';
 
 class RpmClient extends PulpAPI {
   repository = createRepositoryAPI(this);

--- a/src/api/plugins/rpm/client.ts
+++ b/src/api/plugins/rpm/client.ts
@@ -1,0 +1,8 @@
+import { PulpAPI } from "src/api/pulp";
+import { createRepositoryAPI } from "./repository";
+
+class RpmClient extends PulpAPI {
+    repository = createRepositoryAPI(this);
+}
+
+export { RpmClient };

--- a/src/api/plugins/rpm/client.ts
+++ b/src/api/plugins/rpm/client.ts
@@ -1,10 +1,12 @@
 import { PulpAPI } from 'src/api/pulp';
 import { createRemoteAPI } from './remote';
 import { createRepositoryAPI } from './repository';
+import { createDistributionAPI } from './distribution';
 
 class RpmClient extends PulpAPI {
   repository = createRepositoryAPI(this);
   remote = createRemoteAPI(this);
+  distribution = createDistributionAPI(this);
 }
 
 export { RpmClient };

--- a/src/api/plugins/rpm/client.ts
+++ b/src/api/plugins/rpm/client.ts
@@ -1,8 +1,8 @@
-import { PulpAPI } from "src/api/pulp";
-import { createRepositoryAPI } from "./repository";
+import { PulpAPI } from 'src/api/pulp';
+import { createRepositoryAPI } from './repository';
 
 class RpmClient extends PulpAPI {
-    repository = createRepositoryAPI(this);
+  repository = createRepositoryAPI(this);
 }
 
 export { RpmClient };

--- a/src/api/plugins/rpm/client.ts
+++ b/src/api/plugins/rpm/client.ts
@@ -1,6 +1,6 @@
 import { PulpAPI } from 'src/api/pulp';
-import { createRepositoryAPI } from './repository';
 import { createRemoteAPI } from './remote';
+import { createRepositoryAPI } from './repository';
 
 class RpmClient extends PulpAPI {
   repository = createRepositoryAPI(this);

--- a/src/api/plugins/rpm/client.ts
+++ b/src/api/plugins/rpm/client.ts
@@ -2,11 +2,13 @@ import { PulpAPI } from 'src/api/pulp';
 import { createDistributionAPI } from './distribution';
 import { createRemoteAPI } from './remote';
 import { createRepositoryAPI } from './repository';
+import { createPublicationAPI } from './publication';
 
 class RpmClient extends PulpAPI {
   repository = createRepositoryAPI(this);
   remote = createRemoteAPI(this);
   distribution = createDistributionAPI(this);
+  publication = createPublicationAPI(this);
 }
 
 export { RpmClient };

--- a/src/api/plugins/rpm/client.ts
+++ b/src/api/plugins/rpm/client.ts
@@ -1,8 +1,10 @@
 import { PulpAPI } from 'src/api/pulp';
 import { createRepositoryAPI } from './repository';
+import { createRemoteAPI } from './remote';
 
 class RpmClient extends PulpAPI {
   repository = createRepositoryAPI(this);
+  remote = createRemoteAPI(this);
 }
 
 export { RpmClient };

--- a/src/api/plugins/rpm/client.ts
+++ b/src/api/plugins/rpm/client.ts
@@ -1,7 +1,7 @@
 import { PulpAPI } from 'src/api/pulp';
+import { createDistributionAPI } from './distribution';
 import { createRemoteAPI } from './remote';
 import { createRepositoryAPI } from './repository';
-import { createDistributionAPI } from './distribution';
 
 class RpmClient extends PulpAPI {
   repository = createRepositoryAPI(this);

--- a/src/api/plugins/rpm/distribution.test.ts
+++ b/src/api/plugins/rpm/distribution.test.ts
@@ -1,11 +1,12 @@
 import { isAxiosError } from 'axios';
 import assert from 'node:assert/strict';
-import { after, before, describe, it } from 'node:test';
+import { after, afterEach, before, describe, it } from 'node:test';
 import {
   createAndWaitForResource,
   extractIdentifierFromPrn,
   testAxiosClient,
   testPulpAPI,
+  waitForTaskCompletion,
 } from '../../test-utils/integration-client.ts';
 import {
   type RPMDistributionType,
@@ -116,7 +117,135 @@ describe('Integration: RPM Distribution API Client', () => {
     });
   });
 
-  describe.skip('RPM Distribution - create()');
+  describe('RPM Distribution - create()', () => {
+    const testRpmDistributionBasePath = 'test-rpm-distribution-create';
+    let distributionHref: string | undefined;
+
+    afterEach(async () => {
+      if (distributionHref) {
+        await testAxiosClient(distributionHref, { method: 'DELETE' });
+        distributionHref = undefined;
+      }
+    });
+
+    it('create() when giving only the required fields dispatches a task, and the created distribution has expected defaults upon task completion', async () => {
+      const testRpmDistributionName = 'test-rpm-distribution-create-minimal';
+      const client = createDistributionAPI(testPulpAPI());
+
+      const res = await client.create({
+        name: testRpmDistributionName,
+        base_path: testRpmDistributionBasePath,
+      });
+
+      assert.strictEqual(res.status, 202);
+      assert.notStrictEqual(res.data.task, undefined);
+
+      await waitForTaskCompletion(res.data.task);
+      const task = await testAxiosClient(res.data.task, { method: 'GET' });
+      distributionHref = task.data.created_resources?.[0];
+
+      const created = await testAxiosClient(distributionHref, {
+        method: 'GET',
+      });
+
+      assert.strictEqual(created.data.name, testRpmDistributionName);
+      assert.strictEqual(created.data.base_path, testRpmDistributionBasePath);
+      assert.strictEqual(created.data.generate_repo_config, false);
+    });
+
+    it('create() when given additional optional fields dispatches a task and are reflected on task completion', async () => {
+      const testRpmDistributionName = 'test-rpm-distribution-create-full';
+      const client = createDistributionAPI(testPulpAPI());
+      const payload = {
+        name: testRpmDistributionName,
+        base_path: testRpmDistributionBasePath,
+        generate_repo_config: true,
+      } satisfies RPMDistributionType;
+
+      const res = await client.create(payload);
+
+      assert.strictEqual(res.status, 202);
+      assert.notStrictEqual(res.data.task, undefined);
+
+      await waitForTaskCompletion(res.data.task);
+      const task = await testAxiosClient(res.data.task, { method: 'GET' });
+      distributionHref = task.data.created_resources?.[0];
+
+      const created = await testAxiosClient(distributionHref, {
+        method: 'GET',
+      });
+
+      assert.strictEqual(created.data.name, payload.name);
+      assert.strictEqual(created.data.base_path, payload.base_path);
+      assert.strictEqual(
+        created.data.generate_repo_config,
+        payload.generate_repo_config,
+      );
+    });
+
+    it('create() when passed a duplicate base_path returns 400', async () => {
+      const testRpmDistributionNameOne = 'test-rpm-distribution-create-dup-one';
+      const testRpmDistributionNameTwo = 'test-rpm-distribution-create-dup-two';
+      const client = createDistributionAPI(testPulpAPI());
+
+      const firstPayload = await client.create({
+        name: testRpmDistributionNameOne,
+        base_path: testRpmDistributionBasePath,
+      });
+      await waitForTaskCompletion(firstPayload.data.task);
+      const task = await testAxiosClient(firstPayload.data.task, {
+        method: 'GET',
+      });
+      distributionHref = task.data.created_resources?.[0];
+
+      await assert.rejects(
+        () =>
+          client.create({
+            name: testRpmDistributionNameTwo,
+            base_path: testRpmDistributionBasePath,
+          }),
+        (err: unknown) => {
+          assert.ok(isAxiosError(err));
+          assert.strictEqual(err.response?.status, 400);
+          return true;
+        },
+      );
+    });
+
+    it('create() when missing the required name field returns 400', async () => {
+      const client = createDistributionAPI(testPulpAPI());
+
+      await assert.rejects(
+        () =>
+          client.create({
+            base_path: testRpmDistributionBasePath,
+          } as RPMDistributionType),
+        (err: unknown) => {
+          assert.ok(isAxiosError(err));
+          assert.strictEqual(err.response?.status, 400);
+          return true;
+        },
+      );
+    });
+
+    it('create() when missing the required base_path field returns 400', async () => {
+      const testRpmDistributionName =
+        'test-rpm-distribution-create-missing-base-path';
+      const client = createDistributionAPI(testPulpAPI());
+
+      await assert.rejects(
+        () =>
+          client.create({
+            name: testRpmDistributionName,
+          } as RPMDistributionType),
+        (err: unknown) => {
+          assert.ok(isAxiosError(err));
+          assert.strictEqual(err.response?.status, 400);
+          return true;
+        },
+      );
+    });
+  });
 
   describe.skip('RPM Distribution - update()');
 

--- a/src/api/plugins/rpm/distribution.test.ts
+++ b/src/api/plugins/rpm/distribution.test.ts
@@ -1,0 +1,13 @@
+import { describe } from "node:test";
+
+describe('Integration: RPM Distribution API Client', () => {
+    describe('RPM Distribution - list()');
+
+    describe('RPM Distribution - retrieve()');
+
+    describe('RPM Distribution - create()');
+
+    describe('RPM Distribution - update()');
+
+    describe('RPM Distribution - delete()')
+});

--- a/src/api/plugins/rpm/distribution.test.ts
+++ b/src/api/plugins/rpm/distribution.test.ts
@@ -1,11 +1,16 @@
+import { isAxiosError } from 'axios';
 import assert from 'node:assert/strict';
 import { after, before, describe, it } from 'node:test';
 import {
+  createAndWaitForResource,
+  extractIdentifierFromPrn,
   testAxiosClient,
   testPulpAPI,
-  waitForTaskCompletion,
 } from '../../test-utils/integration-client.ts';
-import { createDistributionAPI } from './distribution.ts';
+import {
+  type RPMDistributionType,
+  createDistributionAPI,
+} from './distribution.ts';
 
 describe('Integration: RPM Distribution API Client', () => {
   describe('RPM Distribution - list()', () => {
@@ -14,27 +19,14 @@ describe('Integration: RPM Distribution API Client', () => {
     let distributionHref: string | undefined;
 
     before(async () => {
-      const created = await testAxiosClient('distributions/rpm/rpm/', {
-        method: 'POST',
-        data: JSON.stringify({
+      const created = await createAndWaitForResource<RPMDistributionType>(
+        'distributions/rpm/rpm/',
+        {
           name: testRpmDistributionName,
           base_path: testRpmDistributionBasePath,
-        }),
-      });
-
-      if (!created.data.task) {
-        throw new Error('Failed to dispatch distribution create task');
-      }
-
-      await waitForTaskCompletion(created.data.task);
-      const task = await testAxiosClient(created.data.task, { method: 'GET' });
-      distributionHref = task.data.created_resources?.[0];
-
-      if (!distributionHref) {
-        throw new Error(
-          'Failed to resolve created distribution href from task',
-        );
-      }
+        },
+      );
+      distributionHref = created.pulp_href;
     });
 
     after(async () => {
@@ -72,7 +64,57 @@ describe('Integration: RPM Distribution API Client', () => {
     });
   });
 
-  describe.skip('RPM Distribution - retrieve()');
+  describe('RPM Distribution - retrieve()', () => {
+    const testRpmDistributionName = 'test-rpm-distribution-existent-retrieve';
+    const testRpmDistributionBasePath =
+      'test-rpm-distribution-existent-retrieve';
+    let distributionPrn: string | undefined;
+    let distributionHref: string | undefined;
+
+    before(async () => {
+      const created = await createAndWaitForResource<RPMDistributionType>(
+        'distributions/rpm/rpm/',
+        {
+          name: testRpmDistributionName,
+          base_path: testRpmDistributionBasePath,
+        },
+      );
+      distributionHref = created.pulp_href;
+      distributionPrn = created.prn;
+    });
+
+    after(async () => {
+      await testAxiosClient(distributionHref, { method: 'DELETE' });
+      distributionHref = undefined;
+      distributionPrn = undefined;
+    });
+
+    it('retrieve() when passed correct identifier returns expected distribution', async () => {
+      const distributionIdentifier = extractIdentifierFromPrn(distributionPrn);
+      const client = createDistributionAPI(testPulpAPI());
+
+      const res = await client.retrieve(distributionIdentifier);
+
+      assert.strictEqual(res.status, 200);
+      assert.strictEqual(res.data.prn, distributionPrn);
+      assert.strictEqual(res.data.name, testRpmDistributionName);
+      assert.strictEqual(res.data.base_path, testRpmDistributionBasePath);
+    });
+
+    it('retrieve() when passed a non-existent identifier returns 404', async () => {
+      const nonExistentDistributionIdentifer = '1234567890';
+      const client = createDistributionAPI(testPulpAPI());
+
+      await assert.rejects(
+        () => client.retrieve(nonExistentDistributionIdentifer),
+        (err: unknown) => {
+          assert.ok(isAxiosError(err));
+          assert.strictEqual(err.response?.status, 404);
+          return true;
+        },
+      );
+    });
+  });
 
   describe.skip('RPM Distribution - create()');
 

--- a/src/api/plugins/rpm/distribution.test.ts
+++ b/src/api/plugins/rpm/distribution.test.ts
@@ -1,13 +1,82 @@
-import { describe } from "node:test";
+import assert from 'node:assert/strict';
+import { after, before, describe, it } from 'node:test';
+import {
+  testAxiosClient,
+  testPulpAPI,
+  waitForTaskCompletion,
+} from '../../test-utils/integration-client.ts';
+import { createDistributionAPI } from './distribution.ts';
 
 describe('Integration: RPM Distribution API Client', () => {
-    describe('RPM Distribution - list()');
+  describe('RPM Distribution - list()', () => {
+    const testRpmDistributionName = 'test-rpm-distribution-existent-list';
+    const testRpmDistributionBasePath = 'test-rpm-distribution-existent-list';
+    let distributionHref: string | undefined;
 
-    describe('RPM Distribution - retrieve()');
+    before(async () => {
+      const created = await testAxiosClient('distributions/rpm/rpm/', {
+        method: 'POST',
+        data: JSON.stringify({
+          name: testRpmDistributionName,
+          base_path: testRpmDistributionBasePath,
+        }),
+      });
 
-    describe('RPM Distribution - create()');
+      if (!created.data.task) {
+        throw new Error('Failed to dispatch distribution create task');
+      }
 
-    describe('RPM Distribution - update()');
+      await waitForTaskCompletion(created.data.task);
+      const task = await testAxiosClient(created.data.task, { method: 'GET' });
+      distributionHref = task.data.created_resources?.[0];
 
-    describe('RPM Distribution - delete()')
+      if (!distributionHref) {
+        throw new Error(
+          'Failed to resolve created distribution href from task',
+        );
+      }
+    });
+
+    after(async () => {
+      await testAxiosClient(distributionHref, { method: 'DELETE' });
+      distributionHref = undefined;
+    });
+
+    it('list() finds the created distribution by exact name', async () => {
+      const client = createDistributionAPI(testPulpAPI());
+
+      const res = await client.list({ name: testRpmDistributionName });
+
+      assert.strictEqual(res.status, 200);
+      assert.strictEqual(res.data.count, 1);
+      assert.strictEqual(res.data.count, res.data.results.length);
+      assert.strictEqual(res.data.results[0].name, testRpmDistributionName);
+      assert.strictEqual(res.data.results[0].pulp_href, distributionHref);
+      assert.strictEqual(
+        res.data.results[0].base_path,
+        testRpmDistributionBasePath,
+      );
+    });
+
+    it('list() when passed a non-existent distribution name returns empty result', async () => {
+      const nonExistentDistributionName =
+        'test-rpm-distribution-non-existent-list';
+      const client = createDistributionAPI(testPulpAPI());
+
+      const res = await client.list({ name: nonExistentDistributionName });
+
+      assert.strictEqual(res.status, 200);
+      assert.strictEqual(res.data.count, 0);
+      assert.strictEqual(res.data.results.length, 0);
+      assert.strictEqual(res.data.count, res.data.results.length);
+    });
+  });
+
+  describe.skip('RPM Distribution - retrieve()');
+
+  describe.skip('RPM Distribution - create()');
+
+  describe.skip('RPM Distribution - update()');
+
+  describe.skip('RPM Distribution - delete()');
 });

--- a/src/api/plugins/rpm/distribution.test.ts
+++ b/src/api/plugins/rpm/distribution.test.ts
@@ -1,6 +1,6 @@
 import { isAxiosError } from 'axios';
 import assert from 'node:assert/strict';
-import { after, afterEach, before, describe, it } from 'node:test';
+import { after, afterEach, before, beforeEach, describe, it } from 'node:test';
 import {
   createAndWaitForResource,
   extractIdentifierFromPrn,
@@ -247,7 +247,140 @@ describe('Integration: RPM Distribution API Client', () => {
     });
   });
 
-  describe.skip('RPM Distribution - update()');
+  describe('RPM Distribution - update()', () => {
+    const testRpmDistributionName = 'test-rpm-distribution-existent-update';
+    const testRpmDistributionBasePath = 'test-rpm-distribution-existent-update';
+    let distributionPrn: string | undefined;
+    let distributionHref: string | undefined;
+    let otherDistributionHref: string | undefined;
+
+    beforeEach(async () => {
+      const created = await createAndWaitForResource<RPMDistributionType>(
+        'distributions/rpm/rpm/',
+        {
+          name: testRpmDistributionName,
+          base_path: testRpmDistributionBasePath,
+        },
+      );
+      distributionHref = created.pulp_href;
+      distributionPrn = created.prn;
+    });
+
+    afterEach(async () => {
+      await testAxiosClient(distributionHref, { method: 'DELETE' });
+      distributionHref = undefined;
+      distributionPrn = undefined;
+
+      if (otherDistributionHref) {
+        await testAxiosClient(otherDistributionHref, { method: 'DELETE' });
+        otherDistributionHref = undefined;
+      }
+    });
+
+    it('update() when updated a field with the same value returns 200', async () => {
+      const sameNameValue = testRpmDistributionName;
+      const distributionIdentifier = extractIdentifierFromPrn(distributionPrn);
+      const client = createDistributionAPI(testPulpAPI());
+
+      const res = await client.update(distributionIdentifier, {
+        name: sameNameValue,
+      });
+      const expected = await client.retrieve(distributionIdentifier);
+
+      assert.strictEqual(res.status, 200);
+      assert.strictEqual(expected.data.name, sameNameValue);
+    });
+
+    it('update() with a single changed field returns 202 and updates only that field on task completion', async () => {
+      const distributionIdentifier = extractIdentifierFromPrn(distributionPrn);
+      const client = createDistributionAPI(testPulpAPI());
+
+      const res = await client.update(distributionIdentifier, {
+        generate_repo_config: true,
+      });
+
+      let actual: RPMDistributionType;
+      assert.strictEqual(res.status, 202);
+      if (res.status === 202 && 'task' in res.data) {
+        await waitForTaskCompletion(res.data.task);
+        actual = (await client.retrieve(distributionIdentifier)).data;
+      }
+
+      assert.strictEqual(actual.generate_repo_config, true);
+    });
+
+    it('update() when changing multiple fields returns 202, and all changed fields are reflected on task completion', async () => {
+      const distributionIdentifier = extractIdentifierFromPrn(distributionPrn);
+      const client = createDistributionAPI(testPulpAPI());
+      const payload = {
+        generate_repo_config: true,
+        hidden: true,
+      } satisfies Partial<RPMDistributionType>;
+
+      const res = await client.update(distributionIdentifier, payload);
+
+      let actual: RPMDistributionType;
+      assert.strictEqual(res.status, 202);
+      if (res.status === 202 && 'task' in res.data) {
+        await waitForTaskCompletion(res.data.task);
+        actual = (await client.retrieve(distributionIdentifier)).data;
+      }
+
+      assert.strictEqual(
+        actual.generate_repo_config,
+        payload.generate_repo_config,
+      );
+      assert.strictEqual(
+        actual.hidden,
+        payload.hidden,
+      );
+    });
+
+    it('update() when passed a duplicate base_path returns 400', async () => {
+      const otherDistributionName = 'test-rpm-distribution-update-other';
+      const otherDistributionBasePath = 'test-rpm-distribution-update-other';
+      const created = await createAndWaitForResource<RPMDistributionType>(
+        'distributions/rpm/rpm/',
+        {
+          name: otherDistributionName,
+          base_path: otherDistributionBasePath,
+        },
+      );
+      otherDistributionHref = created.pulp_href;
+
+      const distributionIdentifier = extractIdentifierFromPrn(distributionPrn);
+      const client = createDistributionAPI(testPulpAPI());
+
+      await assert.rejects(
+        () =>
+          client.update(distributionIdentifier, {
+            base_path: otherDistributionBasePath,
+          }),
+        (err: unknown) => {
+          assert.ok(isAxiosError(err));
+          assert.strictEqual(err.response?.status, 400);
+          return true;
+        },
+      );
+    });
+
+    it('update() when passed a non-existent identifier returns 404', async () => {
+      const nonExistentDistributionIdentifier = '1234567890';
+      const client = createDistributionAPI(testPulpAPI());
+
+      await assert.rejects(
+        () =>
+          client.update(nonExistentDistributionIdentifier, {
+            generate_repo_config: true,
+          }),
+        (err: unknown) => {
+          assert.ok(isAxiosError(err));
+          assert.strictEqual(err.response?.status, 404);
+          return true;
+        },
+      );
+    });
+  });
 
   describe.skip('RPM Distribution - delete()');
 });

--- a/src/api/plugins/rpm/distribution.test.ts
+++ b/src/api/plugins/rpm/distribution.test.ts
@@ -330,10 +330,7 @@ describe('Integration: RPM Distribution API Client', () => {
         actual.generate_repo_config,
         payload.generate_repo_config,
       );
-      assert.strictEqual(
-        actual.hidden,
-        payload.hidden,
-      );
+      assert.strictEqual(actual.hidden, payload.hidden);
     });
 
     it('update() when passed a duplicate base_path returns 400', async () => {
@@ -382,5 +379,60 @@ describe('Integration: RPM Distribution API Client', () => {
     });
   });
 
-  describe.skip('RPM Distribution - delete()');
+  describe('RPM Distribution - delete()', () => {
+    it('delete() returns 202 and dispatches a task', async () => {
+      const created = await createAndWaitForResource<RPMDistributionType>(
+        'distributions/rpm/rpm/',
+        {
+          name: 'test-rpm-distribution-delete-valid',
+          base_path: 'test-rpm-distribution-delete-valid',
+        },
+      );
+      const distributionIdentifier = extractIdentifierFromPrn(created.prn);
+      const client = createDistributionAPI(testPulpAPI());
+
+      const res = await client.delete(distributionIdentifier);
+
+      assert.strictEqual(res.status, 202);
+      assert.notStrictEqual(res.data.task, undefined);
+    });
+
+    it('delete() when passed a non-existent identifier returns 404', async () => {
+      const nonExistentDistributionIdentifer = '1234567890';
+      const client = createDistributionAPI(testPulpAPI());
+
+      await assert.rejects(
+        () => client.delete(nonExistentDistributionIdentifer),
+        (err: unknown) => {
+          assert.ok(isAxiosError(err));
+          assert.strictEqual(err.response?.status, 404);
+          return true;
+        },
+      );
+    });
+
+    it('delete() removes the distribution once the dispatched task completes', async () => {
+      const created = await createAndWaitForResource<RPMDistributionType>(
+        'distributions/rpm/rpm/',
+        {
+          name: 'test-rpm-distribution-delete-completion',
+          base_path: 'test-rpm-distribution-delete-completion',
+        },
+      );
+      const distributionIdentifier = extractIdentifierFromPrn(created.prn);
+      const client = createDistributionAPI(testPulpAPI());
+
+      const res = await client.delete(distributionIdentifier);
+      await waitForTaskCompletion(res.data.task);
+
+      await assert.rejects(
+        () => client.retrieve(distributionIdentifier),
+        (err: unknown) => {
+          assert.ok(isAxiosError(err));
+          assert.strictEqual(err.response?.status, 404);
+          return true;
+        },
+      );
+    });
+  });
 });

--- a/src/api/plugins/rpm/distribution.ts
+++ b/src/api/plugins/rpm/distribution.ts
@@ -1,9 +1,14 @@
-import type { GenericDistribution } from 'src/api/common';
+import type { AxiosResponse } from 'axios';
+import type {
+  GenericDistribution,
+  GenericDistributionFilterParams,
+  PaginatedResponse,
+} from 'src/api/common';
 import type { PulpAPI } from 'src/api/pulp';
 
 /**
  * RPM Distribution Type.
- * 
+ *
  * @see https://github.com/pulp/pulp_rpm/blob/dc333a99db6c44d70d6103540cb592f6e55a8682/pulp_rpm/app/serializers/repository.py#L575
  */
 interface RPMDistributionType extends GenericDistribution {
@@ -15,7 +20,9 @@ interface RPMDistributionType extends GenericDistribution {
 // FIXME: Move AxiosResponse type to PulpAPI Base Class.
 // NOTE: The FIXME implementation is not easy as to avoid major type issues with legacy API calls.
 interface RPMDistributionClient {
-  list: () => void;
+  list: (
+    params?: GenericDistributionFilterParams,
+  ) => Promise<AxiosResponse<PaginatedResponse<RPMDistributionType>>>;
   retrieve: () => void;
   create: () => void;
   update: () => void;
@@ -26,12 +33,12 @@ interface RPMDistributionClient {
  * RPM Distribution API Client
  * @param {PulpAPI} base
  * @returns
- * 
+ *
  * @see https://github.com/pulp/pulp_rpm/blob/dc333a99db6c44d70d6103540cb592f6e55a8682/pulp_rpm/app/viewsets/repository.py#L636
  */
 function createDistributionAPI(base: PulpAPI): RPMDistributionClient {
   return {
-    list: () => undefined,
+    list: (params?) => base.list(`distributions/rpm/rpm/`, params),
     retrieve: () => undefined,
     create: () => undefined,
     update: () => undefined,

--- a/src/api/plugins/rpm/distribution.ts
+++ b/src/api/plugins/rpm/distribution.ts
@@ -23,7 +23,7 @@ interface RPMDistributionClient {
   list: (
     params?: GenericDistributionFilterParams,
   ) => Promise<AxiosResponse<PaginatedResponse<RPMDistributionType>>>;
-  retrieve: () => void;
+  retrieve: (id: string) => Promise<AxiosResponse<RPMDistributionType>>;
   create: () => void;
   update: () => void;
   delete: () => void;
@@ -39,7 +39,7 @@ interface RPMDistributionClient {
 function createDistributionAPI(base: PulpAPI): RPMDistributionClient {
   return {
     list: (params?) => base.list(`distributions/rpm/rpm/`, params),
-    retrieve: () => undefined,
+    retrieve: (id) => base.http.get(`distributions/rpm/rpm/${id}/`),
     create: () => undefined,
     update: () => undefined,
     delete: () => undefined,

--- a/src/api/plugins/rpm/distribution.ts
+++ b/src/api/plugins/rpm/distribution.ts
@@ -1,5 +1,6 @@
 import type { AxiosResponse } from 'axios';
 import type {
+  DispatchedTaskResponse,
   GenericDistribution,
   GenericDistributionFilterParams,
   PaginatedResponse,
@@ -24,7 +25,9 @@ interface RPMDistributionClient {
     params?: GenericDistributionFilterParams,
   ) => Promise<AxiosResponse<PaginatedResponse<RPMDistributionType>>>;
   retrieve: (id: string) => Promise<AxiosResponse<RPMDistributionType>>;
-  create: () => void;
+  create: (
+    data: RPMDistributionType,
+  ) => Promise<AxiosResponse<DispatchedTaskResponse>>;
   update: () => void;
   delete: () => void;
 }
@@ -40,7 +43,7 @@ function createDistributionAPI(base: PulpAPI): RPMDistributionClient {
   return {
     list: (params?) => base.list(`distributions/rpm/rpm/`, params),
     retrieve: (id) => base.http.get(`distributions/rpm/rpm/${id}/`),
-    create: () => undefined,
+    create: (data) => base.http.post(`distributions/rpm/rpm/`, data),
     update: () => undefined,
     delete: () => undefined,
   };

--- a/src/api/plugins/rpm/distribution.ts
+++ b/src/api/plugins/rpm/distribution.ts
@@ -28,7 +28,10 @@ interface RPMDistributionClient {
   create: (
     data: RPMDistributionType,
   ) => Promise<AxiosResponse<DispatchedTaskResponse>>;
-  update: () => void;
+  update: (
+    id: string,
+    data: Partial<RPMDistributionType>,
+  ) => Promise<AxiosResponse<RPMDistributionType | DispatchedTaskResponse>>;
   delete: () => void;
 }
 
@@ -44,7 +47,7 @@ function createDistributionAPI(base: PulpAPI): RPMDistributionClient {
     list: (params?) => base.list(`distributions/rpm/rpm/`, params),
     retrieve: (id) => base.http.get(`distributions/rpm/rpm/${id}/`),
     create: (data) => base.http.post(`distributions/rpm/rpm/`, data),
-    update: () => undefined,
+    update: (id, data) => base.http.patch(`distributions/rpm/rpm/${id}/`, data),
     delete: () => undefined,
   };
 }

--- a/src/api/plugins/rpm/distribution.ts
+++ b/src/api/plugins/rpm/distribution.ts
@@ -1,0 +1,43 @@
+import type { GenericDistribution } from 'src/api/common';
+import type { PulpAPI } from 'src/api/pulp';
+
+/**
+ * RPM Distribution Type.
+ * 
+ * @see https://github.com/pulp/pulp_rpm/blob/dc333a99db6c44d70d6103540cb592f6e55a8682/pulp_rpm/app/serializers/repository.py#L575
+ */
+interface RPMDistributionType extends GenericDistribution {
+  publication?: string | null;
+  generate_repo_config?: boolean;
+  checkpoint?: boolean;
+}
+
+// FIXME: Move AxiosResponse type to PulpAPI Base Class.
+// NOTE: The FIXME implementation is not easy as to avoid major type issues with legacy API calls.
+interface RPMDistributionClient {
+  list: () => void;
+  retrieve: () => void;
+  create: () => void;
+  update: () => void;
+  delete: () => void;
+}
+
+/**
+ * RPM Distribution API Client
+ * @param {PulpAPI} base
+ * @returns
+ * 
+ * @see https://github.com/pulp/pulp_rpm/blob/dc333a99db6c44d70d6103540cb592f6e55a8682/pulp_rpm/app/viewsets/repository.py#L636
+ */
+function createDistributionAPI(base: PulpAPI): RPMDistributionClient {
+  return {
+    list: () => undefined,
+    retrieve: () => undefined,
+    create: () => undefined,
+    update: () => undefined,
+    delete: () => undefined,
+  };
+}
+
+export { createDistributionAPI };
+export type { RPMDistributionType };

--- a/src/api/plugins/rpm/distribution.ts
+++ b/src/api/plugins/rpm/distribution.ts
@@ -32,7 +32,7 @@ interface RPMDistributionClient {
     id: string,
     data: Partial<RPMDistributionType>,
   ) => Promise<AxiosResponse<RPMDistributionType | DispatchedTaskResponse>>;
-  delete: () => void;
+  delete: (id: string) => Promise<AxiosResponse<DispatchedTaskResponse>>;
 }
 
 /**
@@ -48,7 +48,7 @@ function createDistributionAPI(base: PulpAPI): RPMDistributionClient {
     retrieve: (id) => base.http.get(`distributions/rpm/rpm/${id}/`),
     create: (data) => base.http.post(`distributions/rpm/rpm/`, data),
     update: (id, data) => base.http.patch(`distributions/rpm/rpm/${id}/`, data),
-    delete: () => undefined,
+    delete: (id) => base.http.delete(`distributions/rpm/rpm/${id}/`),
   };
 }
 

--- a/src/api/plugins/rpm/publication.test.ts
+++ b/src/api/plugins/rpm/publication.test.ts
@@ -1,6 +1,6 @@
 import { isAxiosError } from 'axios';
 import assert from 'node:assert/strict';
-import { after, afterEach, before, describe, it } from 'node:test';
+import { after, afterEach, before, beforeEach, describe, it } from 'node:test';
 import {
   createAndWaitForResource,
   extractIdentifierFromPrn,
@@ -315,6 +315,76 @@ describe('Integration: RPM Publication API Client', () => {
         (err: unknown) => {
           assert.ok(isAxiosError(err));
           assert.strictEqual(err.response?.status, 400);
+          return true;
+        },
+      );
+    });
+  });
+
+  describe('RPM Publication - delete()', () => {
+    const testRpmRepositoryName = 'test-rpm-repository-publication-delete';
+    let repositoryHref: string | undefined;
+    let publicationHref: string | undefined;
+    let publicationPrn: string | undefined;
+
+    beforeEach(async () => {
+      const repo = await createAndWaitForResource<RPMRepositoryType>(
+        'repositories/rpm/rpm/',
+        {
+          name: testRpmRepositoryName,
+        },
+      );
+      repositoryHref = repo.pulp_href;
+
+      const pub = await createAndWaitForResource<RPMPublicationType>(
+        'publications/rpm/rpm/',
+        {
+          repository: repositoryHref,
+        },
+      );
+      publicationHref = pub.pulp_href;
+      publicationPrn = pub.prn;
+    });
+
+    afterEach(async () => {
+      if (publicationHref) {
+        await testAxiosClient(publicationHref, { method: 'DELETE' });
+      }
+
+      await testAxiosClient(repositoryHref, { method: 'DELETE' });
+      publicationHref = undefined;
+      publicationPrn = undefined;
+      repositoryHref = undefined;
+    });
+
+    it('delete() returns 204 and removes the publication', async () => {
+      const client = createPublicationAPI(testPulpAPI());
+      const publicationIdentifier = extractIdentifierFromPrn(publicationPrn);
+
+      const res = await client.delete(publicationIdentifier);
+
+      assert.strictEqual(res.status, 204);
+      await assert.rejects(
+        () => client.retrieve(publicationIdentifier),
+        (err: unknown) => {
+          assert.ok(isAxiosError(err));
+          assert.strictEqual(err.response?.status, 404);
+          return true;
+        },
+      );
+
+      publicationHref = undefined;
+    });
+
+    it('delete() when passed a non-existent identifier returns 404', async () => {
+      const nonExistentPublicationIdentifier = '1234567890';
+      const client = createPublicationAPI(testPulpAPI());
+
+      await assert.rejects(
+        () => client.delete(nonExistentPublicationIdentifier),
+        (err: unknown) => {
+          assert.ok(isAxiosError(err));
+          assert.strictEqual(err.response?.status, 404);
           return true;
         },
       );

--- a/src/api/plugins/rpm/publication.test.ts
+++ b/src/api/plugins/rpm/publication.test.ts
@@ -1,14 +1,16 @@
 import { isAxiosError } from 'axios';
 import assert from 'node:assert/strict';
-import { after, before, describe, it } from 'node:test';
+import { after, afterEach, before, describe, it } from 'node:test';
 import {
   createAndWaitForResource,
   extractIdentifierFromPrn,
   testAxiosClient,
   testPulpAPI,
+  waitForTaskCompletion,
 } from '../../test-utils/integration-client.ts';
 import {
   type RPMPublicationType,
+  type RPMPublicationUpsertType,
   createPublicationAPI,
 } from './publication.ts';
 import type { RPMRepositoryType } from './repository.ts';
@@ -123,6 +125,196 @@ describe('Integration: RPM Publication API Client', () => {
         (err: unknown) => {
           assert.ok(isAxiosError(err));
           assert.strictEqual(err.response?.status, 404);
+          return true;
+        },
+      );
+    });
+  });
+
+  describe('RPM Publication - create()', () => {
+    let repositoryHref: string | undefined;
+    let publicationHref: string | undefined;
+
+    afterEach(async () => {
+      if (publicationHref) {
+        await testAxiosClient(publicationHref, { method: 'DELETE' });
+        publicationHref = undefined;
+      }
+
+      if (repositoryHref) {
+        await testAxiosClient(repositoryHref, { method: 'DELETE' });
+        repositoryHref = undefined;
+      }
+    });
+
+    it('create() when given only a repository dispatches task, and the publication exists on task completion', async () => {
+      const testRpmRepositoryName =
+        'test-rpm-repository-publication-create-repo';
+      const repo = await createAndWaitForResource<RPMRepositoryType>(
+        'repositories/rpm/rpm/',
+        {
+          name: testRpmRepositoryName,
+        },
+      );
+      repositoryHref = repo.pulp_href;
+      const client = createPublicationAPI(testPulpAPI());
+
+      const res = await client.create({ repository: repositoryHref });
+
+      assert.strictEqual(res.status, 202);
+      assert.notStrictEqual(res.data.task, undefined);
+
+      await waitForTaskCompletion(res.data.task);
+      const task = await testAxiosClient(res.data.task, { method: 'GET' });
+      publicationHref = task.data.created_resources?.[0];
+
+      const created = await testAxiosClient(publicationHref, { method: 'GET' });
+      assert.strictEqual(created.data.repository, repositoryHref);
+      assert.strictEqual(created.data.pulp_href, publicationHref);
+    });
+
+    it('create() when given only a repository_version dispatches task, and publication exists on task completion', async () => {
+      const testRpmRepositoryName =
+        'test-rpm-repository-publication-create-version';
+      const repo = await createAndWaitForResource<RPMRepositoryType>(
+        'repositories/rpm/rpm/',
+        {
+          name: testRpmRepositoryName,
+        },
+      );
+      repositoryHref = repo.pulp_href;
+      const repositoryVersionHref = `${repositoryHref}versions/0/`;
+      const client = createPublicationAPI(testPulpAPI());
+
+      const res = await client.create({
+        repository_version: repositoryVersionHref,
+      });
+
+      assert.strictEqual(res.status, 202);
+      assert.notStrictEqual(res.data.task, undefined);
+
+      await waitForTaskCompletion(res.data.task);
+      const task = await testAxiosClient(res.data.task, { method: 'GET' });
+      publicationHref = task.data.created_resources?.[0];
+
+      const created = await testAxiosClient(publicationHref, { method: 'GET' });
+      assert.strictEqual(
+        created.data.repository_version,
+        repositoryVersionHref,
+      );
+      assert.strictEqual(created.data.pulp_href, publicationHref);
+    });
+
+    it('create() when given additional optional fields dispatches task, and are shown on publication when task completes', async () => {
+      const repo = await createAndWaitForResource<RPMRepositoryType>(
+        'repositories/rpm/rpm/',
+        { name: 'test-rpm-repository-publication-create-optional' },
+      );
+      repositoryHref = repo.pulp_href;
+      const client = createPublicationAPI(testPulpAPI());
+      const payload = {
+        repository: repositoryHref,
+        checksum_type: 'sha256',
+        compression_type: 'gz',
+        layout: 'flat',
+      } satisfies RPMPublicationType;
+
+      const res = await client.create(payload);
+
+      assert.strictEqual(res.status, 202);
+      assert.notStrictEqual(res.data.task, undefined);
+
+      await waitForTaskCompletion(res.data.task);
+      const task = await testAxiosClient(res.data.task, { method: 'GET' });
+      publicationHref = task.data.created_resources?.[0];
+
+      const created = await testAxiosClient(publicationHref, { method: 'GET' });
+      assert.strictEqual(created.data.checksum_type, payload.checksum_type);
+      assert.strictEqual(created.data.repository, payload.repository);
+      assert.strictEqual(created.data.layout, payload.layout);
+      assert.strictEqual(
+        created.data.compression_type,
+        payload.compression_type,
+      );
+    });
+
+    it('create() with checkpoint and repository dispatches a task, and completes successfully', async () => {
+      const repo = await createAndWaitForResource<RPMRepositoryType>(
+        'repositories/rpm/rpm/',
+        { name: 'test-rpm-repository-publication-create-checkpoint' },
+      );
+      repositoryHref = repo.pulp_href;
+      const client = createPublicationAPI(testPulpAPI());
+
+      const res = await client.create({
+        repository: repositoryHref,
+        checkpoint: true,
+      });
+
+      assert.strictEqual(res.status, 202);
+      assert.notStrictEqual(res.data.task, undefined);
+
+      await waitForTaskCompletion(res.data.task);
+      const task = await testAxiosClient(res.data.task, { method: 'GET' });
+      publicationHref = task.data.created_resources?.[0];
+
+      const created = await testAxiosClient(publicationHref, { method: 'GET' });
+      assert.strictEqual(created.data.checkpoint, true);
+    });
+
+    it('create() when checkpoint is passed with repository_version returns 400', async () => {
+      const repo = await createAndWaitForResource<RPMRepositoryType>(
+        'repositories/rpm/rpm/',
+        { name: 'test-rpm-repository-publication-create-checkpoint-version' },
+      );
+      repositoryHref = repo.pulp_href;
+      const repositoryVersionHref = `${repositoryHref}versions/0/`;
+      const client = createPublicationAPI(testPulpAPI());
+
+      await assert.rejects(
+        () =>
+          client.create({
+            repository_version: repositoryVersionHref,
+            checkpoint: true,
+          }),
+        (err: unknown) => {
+          assert.ok(isAxiosError(err));
+          assert.strictEqual(err.response?.status, 400);
+          return true;
+        },
+      );
+    });
+
+    it('create() when missing both repository and repository_version returns 400', async () => {
+      const client = createPublicationAPI(testPulpAPI());
+
+      await assert.rejects(
+        () => client.create({}),
+        (err: unknown) => {
+          assert.ok(isAxiosError(err));
+          assert.strictEqual(err.response?.status, 400);
+          return true;
+        },
+      );
+    });
+
+    it('create() when an invalid checksum_type is passed returns 400', async () => {
+      const repo = await createAndWaitForResource<RPMRepositoryType>(
+        'repositories/rpm/rpm/',
+        { name: 'test-rpm-repository-publication-bad-checksum' },
+      );
+      repositoryHref = repo.pulp_href;
+      const client = createPublicationAPI(testPulpAPI());
+
+      await assert.rejects(
+        () =>
+          client.create({
+            repository: repositoryHref,
+            checksum_type: 'md5' as RPMPublicationUpsertType['checksum_type'],
+          }),
+        (err: unknown) => {
+          assert.ok(isAxiosError(err));
+          assert.strictEqual(err.response?.status, 400);
           return true;
         },
       );

--- a/src/api/plugins/rpm/publication.test.ts
+++ b/src/api/plugins/rpm/publication.test.ts
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 import { after, before, describe, it } from 'node:test';
 import {
   createAndWaitForResource,
+  extractIdentifierFromPrn,
   testAxiosClient,
   testPulpAPI,
 } from '../../test-utils/integration-client.ts';
@@ -62,6 +63,66 @@ describe('Integration: RPM Publication API Client', () => {
         (err: unknown) => {
           assert.ok(isAxiosError(err));
           assert.strictEqual(err.response?.status, 400);
+          return true;
+        },
+      );
+    });
+  });
+
+  describe('RPM Publication - retrieve()', () => {
+    const testRpmRepositoryName = 'test-rpm-repository-publication-retrieve';
+    let repositoryHref: string | undefined;
+    let publicationHref: string | undefined;
+    let publicationPrn: string | undefined;
+
+    before(async () => {
+      const repo = await createAndWaitForResource<RPMRepositoryType>(
+        'repositories/rpm/rpm/',
+        {
+          name: testRpmRepositoryName,
+        },
+      );
+      repositoryHref = repo.pulp_href;
+
+      const pub = await createAndWaitForResource<RPMPublicationType>(
+        'publications/rpm/rpm/',
+        {
+          repository: repositoryHref,
+        },
+      );
+      publicationHref = pub.pulp_href;
+      publicationPrn = pub.prn;
+    });
+
+    after(async () => {
+      await testAxiosClient(publicationHref, { method: 'DELETE' });
+      await testAxiosClient(repositoryHref, { method: 'DELETE' });
+      publicationHref = undefined;
+      publicationPrn = undefined;
+      repositoryHref = undefined;
+    });
+
+    it('retrieve() when passed correct identifier returns expected publication', async () => {
+      const client = createPublicationAPI(testPulpAPI());
+      const publicationIdentifier = extractIdentifierFromPrn(publicationPrn);
+
+      const res = await client.retrieve(publicationIdentifier);
+
+      assert.strictEqual(res.status, 200);
+      assert.strictEqual(res.data.prn, publicationPrn);
+      assert.strictEqual(res.data.repository, repositoryHref);
+      assert.strictEqual(res.data.pulp_href, publicationHref);
+    });
+
+    it('retrieve() when passed a non-existent identifier returns 404', async () => {
+      const nonExistentPublicationIdentifier = '1234567890';
+      const client = createPublicationAPI(testPulpAPI());
+
+      await assert.rejects(
+        () => client.retrieve(nonExistentPublicationIdentifier),
+        (err: unknown) => {
+          assert.ok(isAxiosError(err));
+          assert.strictEqual(err.response?.status, 404);
           return true;
         },
       );

--- a/src/api/plugins/rpm/publication.test.ts
+++ b/src/api/plugins/rpm/publication.test.ts
@@ -1,0 +1,70 @@
+import { isAxiosError } from 'axios';
+import assert from 'node:assert/strict';
+import { after, before, describe, it } from 'node:test';
+import {
+  createAndWaitForResource,
+  testAxiosClient,
+  testPulpAPI,
+} from '../../test-utils/integration-client.ts';
+import {
+  type RPMPublicationType,
+  createPublicationAPI,
+} from './publication.ts';
+import type { RPMRepositoryType } from './repository.ts';
+
+describe('Integration: RPM Publication API Client', () => {
+  describe('RPM Publication - list()', () => {
+    const testRpmRepositoryName = 'test-rpm-repository-publication-list';
+    let repositoryHref: string | undefined;
+    let publicationHref: string | undefined;
+
+    before(async () => {
+      const repo = await createAndWaitForResource<RPMRepositoryType>(
+        'repositories/rpm/rpm/',
+        {
+          name: testRpmRepositoryName,
+        },
+      );
+      repositoryHref = repo.pulp_href;
+
+      const pub = await createAndWaitForResource<RPMPublicationType>(
+        'publications/rpm/rpm/',
+        { repository: repositoryHref },
+      );
+      publicationHref = pub.pulp_href;
+    });
+
+    after(async () => {
+      await testAxiosClient(publicationHref, { method: 'DELETE' });
+      await testAxiosClient(repositoryHref, { method: 'DELETE' });
+      publicationHref = undefined;
+      repositoryHref = undefined;
+    });
+
+    it('list() finds the created publication by repository', async () => {
+      const client = createPublicationAPI(testPulpAPI());
+
+      const res = await client.list({ repository: repositoryHref });
+
+      assert.strictEqual(res.status, 200);
+      assert.strictEqual(res.data.count, 1);
+      assert.strictEqual(res.data.count, res.data.results.length);
+      assert.strictEqual(res.data.results[0].pulp_href, publicationHref);
+    });
+
+    it('list() when passed a non-existent repository returns 400', async () => {
+      const nonExistentRepositoryHref =
+        'http://localhost:8080/pulp/api/v3/repositories/rpm/rpm/01a01966-4c52-7b2e-99fc-5de89da79075/';
+      const client = createPublicationAPI(testPulpAPI());
+
+      await assert.rejects(
+        () => client.list({ repository: nonExistentRepositoryHref }),
+        (err: unknown) => {
+          assert.ok(isAxiosError(err));
+          assert.strictEqual(err.response?.status, 400);
+          return true;
+        },
+      );
+    });
+  });
+});

--- a/src/api/plugins/rpm/publication.ts
+++ b/src/api/plugins/rpm/publication.ts
@@ -1,4 +1,9 @@
-import type { GenericPublication } from 'src/api/common';
+import type { AxiosResponse } from 'axios';
+import type {
+  GenericPublication,
+  GenericPublicationFilterParams,
+  PaginatedResponse,
+} from 'src/api/common';
 import type { PulpAPI } from 'src/api/pulp';
 import type {
   RPMChecksumType,
@@ -8,7 +13,7 @@ import type {
 
 /**
  * RPM Publication Type.
- * 
+ *
  * @see https://github.com/pulp/pulp_rpm/blob/dc333a99db6c44d70d6103540cb592f6e55a8682/pulp_rpm/app/serializers/repository.py#L474
  */
 interface RPMPublicationType extends GenericPublication {
@@ -22,7 +27,9 @@ interface RPMPublicationType extends GenericPublication {
 // FIXME: Move AxiosResponse type to PulpAPI Base Class.
 // NOTE: The FIXME implementation is not easy as to avoid major type issues with legacy API calls.
 interface RPMPublicationClient {
-  list: () => void;
+  list: (
+    params?: GenericPublicationFilterParams,
+  ) => Promise<AxiosResponse<PaginatedResponse<RPMPublicationType>>>;
   retrieve: () => void;
   create: () => void;
   delete: () => void;
@@ -30,14 +37,14 @@ interface RPMPublicationClient {
 
 /**
  * RPM Publication API Client.
- * @param {PulpAPI} base 
+ * @param {PulpAPI} base
  * @returns {RPMPublicationClient}
- * 
+ *
  * @see https://github.com/pulp/pulp_rpm/blob/dc333a99db6c44d70d6103540cb592f6e55a8682/pulp_rpm/app/viewsets/repository.py#L519
  */
 function createPublicationAPI(base: PulpAPI): RPMPublicationClient {
   return {
-    list: () => undefined,
+    list: (params?) => base.list(`publications/rpm/rpm/`, params),
     retrieve: () => undefined,
     create: () => undefined,
     delete: () => undefined,

--- a/src/api/plugins/rpm/publication.ts
+++ b/src/api/plugins/rpm/publication.ts
@@ -1,11 +1,13 @@
 import type { AxiosResponse } from 'axios';
 import type {
+  DispatchedTaskResponse,
   GenericPublication,
   GenericPublicationFilterParams,
   PaginatedResponse,
 } from 'src/api/common';
 import type { PulpAPI } from 'src/api/pulp';
 import type {
+  RPMAllowedUpsertChecksumsType,
   RPMChecksumType,
   RPMCompressionType,
   RPMLayoutType,
@@ -24,6 +26,18 @@ interface RPMPublicationType extends GenericPublication {
   repo_config?: Record<string, unknown>;
 }
 
+/**
+ * RPM Publication Create Type.
+ *
+ * @see https://github.com/pulp/pulp_rpm/blob/dc333a99db6c44d70d6103540cb592f6e55a8682/pulp_rpm/app/serializers/repository.py#L547
+ */
+interface RPMPublicationUpsertType extends Omit<
+  RPMPublicationType,
+  'checksum_type'
+> {
+  checksum_type?: RPMAllowedUpsertChecksumsType;
+}
+
 // FIXME: Move AxiosResponse type to PulpAPI Base Class.
 // NOTE: The FIXME implementation is not easy as to avoid major type issues with legacy API calls.
 interface RPMPublicationClient {
@@ -31,7 +45,9 @@ interface RPMPublicationClient {
     params?: GenericPublicationFilterParams,
   ) => Promise<AxiosResponse<PaginatedResponse<RPMPublicationType>>>;
   retrieve: (id: string) => Promise<AxiosResponse<RPMPublicationType>>;
-  create: () => void;
+  create: (
+    data: RPMPublicationUpsertType,
+  ) => Promise<AxiosResponse<DispatchedTaskResponse>>;
   delete: () => void;
 }
 
@@ -46,10 +62,10 @@ function createPublicationAPI(base: PulpAPI): RPMPublicationClient {
   return {
     list: (params?) => base.list(`publications/rpm/rpm/`, params),
     retrieve: (id) => base.http.get(`publications/rpm/rpm/${id}/`),
-    create: () => undefined,
+    create: (data) => base.http.post(`publications/rpm/rpm/`, data),
     delete: () => undefined,
   };
 }
 
 export { createPublicationAPI };
-export type { RPMPublicationType };
+export type { RPMPublicationType, RPMPublicationUpsertType };

--- a/src/api/plugins/rpm/publication.ts
+++ b/src/api/plugins/rpm/publication.ts
@@ -48,7 +48,7 @@ interface RPMPublicationClient {
   create: (
     data: RPMPublicationUpsertType,
   ) => Promise<AxiosResponse<DispatchedTaskResponse>>;
-  delete: () => void;
+  delete: (id: string) => Promise<AxiosResponse<void>>;
 }
 
 /**
@@ -63,7 +63,7 @@ function createPublicationAPI(base: PulpAPI): RPMPublicationClient {
     list: (params?) => base.list(`publications/rpm/rpm/`, params),
     retrieve: (id) => base.http.get(`publications/rpm/rpm/${id}/`),
     create: (data) => base.http.post(`publications/rpm/rpm/`, data),
-    delete: () => undefined,
+    delete: (id) => base.http.delete(`publications/rpm/rpm/${id}/`),
   };
 }
 

--- a/src/api/plugins/rpm/publication.ts
+++ b/src/api/plugins/rpm/publication.ts
@@ -30,7 +30,7 @@ interface RPMPublicationClient {
   list: (
     params?: GenericPublicationFilterParams,
   ) => Promise<AxiosResponse<PaginatedResponse<RPMPublicationType>>>;
-  retrieve: () => void;
+  retrieve: (id: string) => Promise<AxiosResponse<RPMPublicationType>>;
   create: () => void;
   delete: () => void;
 }
@@ -45,7 +45,7 @@ interface RPMPublicationClient {
 function createPublicationAPI(base: PulpAPI): RPMPublicationClient {
   return {
     list: (params?) => base.list(`publications/rpm/rpm/`, params),
-    retrieve: () => undefined,
+    retrieve: (id) => base.http.get(`publications/rpm/rpm/${id}/`),
     create: () => undefined,
     delete: () => undefined,
   };

--- a/src/api/plugins/rpm/publication.ts
+++ b/src/api/plugins/rpm/publication.ts
@@ -1,0 +1,48 @@
+import type { GenericPublication } from 'src/api/common';
+import type { PulpAPI } from 'src/api/pulp';
+import type {
+  RPMChecksumType,
+  RPMCompressionType,
+  RPMLayoutType,
+} from './types';
+
+/**
+ * RPM Publication Type.
+ * 
+ * @see https://github.com/pulp/pulp_rpm/blob/dc333a99db6c44d70d6103540cb592f6e55a8682/pulp_rpm/app/serializers/repository.py#L474
+ */
+interface RPMPublicationType extends GenericPublication {
+  checkpoint?: boolean;
+  checksum_type?: RPMChecksumType;
+  compression_type?: RPMCompressionType;
+  layout?: RPMLayoutType | null;
+  repo_config?: Record<string, unknown>;
+}
+
+// FIXME: Move AxiosResponse type to PulpAPI Base Class.
+// NOTE: The FIXME implementation is not easy as to avoid major type issues with legacy API calls.
+interface RPMPublicationClient {
+  list: () => void;
+  retrieve: () => void;
+  create: () => void;
+  delete: () => void;
+}
+
+/**
+ * RPM Publication API Client.
+ * @param {PulpAPI} base 
+ * @returns {RPMPublicationClient}
+ * 
+ * @see https://github.com/pulp/pulp_rpm/blob/dc333a99db6c44d70d6103540cb592f6e55a8682/pulp_rpm/app/viewsets/repository.py#L519
+ */
+function createPublicationAPI(base: PulpAPI): RPMPublicationClient {
+  return {
+    list: () => undefined,
+    retrieve: () => undefined,
+    create: () => undefined,
+    delete: () => undefined,
+  };
+}
+
+export { createPublicationAPI };
+export type { RPMPublicationType };

--- a/src/api/plugins/rpm/remote.test.ts
+++ b/src/api/plugins/rpm/remote.test.ts
@@ -1,0 +1,55 @@
+import { after, before, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { createRemoteAPI } from './remote.ts';
+import { testAxiosClient, testPulpAPI } from '../../test-utils/integration-client.ts';
+
+describe('Integration: RPM Remote API Client', () => {
+    describe('RPM Remote - list()', () => {
+        const testRpmRemoteName = 'test-rpm-remote-existent-list';
+        const testRpmRemoteUrl = 'https://example.com/repo/';
+        let remoteHref: string | undefined;
+
+        before(async () => {
+            const res = await testAxiosClient('remotes/rpm/rpm/', {
+                method: "POST",
+                data: JSON.stringify({ name: testRpmRemoteName, url: testRpmRemoteUrl }),
+            })
+            
+            if (!res.data.pulp_href) {
+                throw new Error('Failed to create test remote')
+            }
+
+            remoteHref = res.data.pulp_href;
+        });
+
+        after(async () => {
+            await testAxiosClient(remoteHref, { method: "DELETE" });
+            remoteHref = undefined;
+        })
+
+        it('list() finds the created remote by exact name', async () => {
+            const client = createRemoteAPI(testPulpAPI());
+
+            const res = await client.list({ name: testRpmRemoteName });
+
+            assert.strictEqual(res.status, 200);
+            assert.strictEqual(res.data.count, 1);
+            assert.strictEqual(res.data.count, res.data.results.length);
+            assert.strictEqual(res.data.results[0].name, testRpmRemoteName);
+            assert.strictEqual(res.data.results[0].pulp_href, remoteHref);
+            assert.strictEqual(res.data.results[0].url, testRpmRemoteUrl);
+        });
+
+        it('list() when passed a non-existent remote name returns empty result', async () => {
+            const nonExistentRemoteName = 'test-rpm-remote-non-existent-list';
+            const client = createRemoteAPI(testPulpAPI());
+
+            const res = await client.list({ name: nonExistentRemoteName });
+
+            assert.strictEqual(res.status, 200);
+            assert.strictEqual(res.data.count, 0);
+            assert.strictEqual(res.data.count, 0);
+            assert.strictEqual(res.data.count, res.data.results.length);
+        })
+    });
+});

--- a/src/api/plugins/rpm/remote.test.ts
+++ b/src/api/plugins/rpm/remote.test.ts
@@ -91,7 +91,7 @@ describe('Integration: RPM Remote API Client', () => {
       remoteHref = undefined;
     });
 
-    it('retrieve() whe passed correct identifier returns expected remote', async () => {
+    it('retrieve() when passed correct identifier returns expected remote', async () => {
       const remoteIdentifier = extractIdentifierFromPrn(remotePrn);
       const client = createRemoteAPI(testPulpAPI());
 
@@ -354,6 +354,57 @@ describe('Integration: RPM Remote API Client', () => {
           client.update(nonExistentRemoteIdentifier, {
             rate_limit: 9000,
           }),
+        (err: unknown) => {
+          assert.ok(isAxiosError(err));
+          assert.strictEqual(err.response?.status, 404);
+          return true;
+        },
+      );
+    });
+  });
+
+  describe('RPM Remote - delete()', () => {
+    it('delete() returns 202 and dispatches a task', async () => {
+      const client = createRemoteAPI(testPulpAPI());
+      const created = await client.create({
+        name: 'test-rpm-remote-delete',
+        url: 'https://example.com/repo/',
+      });
+      const remoteIdentifier = extractIdentifierFromPrn(created.data.prn);
+
+      const res = await client.delete(remoteIdentifier);
+
+      assert.strictEqual(res.status, 202);
+      assert.notStrictEqual(res.data.task, undefined);
+    });
+
+    it('delete() when passes a non-existent identifier returns 404', async () => {
+      const nonExistentRemoteIdentifier = '1234567890';
+      const client = createRemoteAPI(testPulpAPI());
+
+      await assert.rejects(
+        () => client.delete(nonExistentRemoteIdentifier),
+        (err: unknown) => {
+          assert.ok(isAxiosError(err));
+          assert.strictEqual(err.response?.status, 404);
+          return true;
+        },
+      );
+    });
+
+    it('delete() removes the remote once the dispatched task completes', async () => {
+      const client = createRemoteAPI(testPulpAPI());
+      const created = await client.create({
+        name: 'test-rpm-remote-delete',
+        url: 'https://example.com/repo/',
+      });
+      const remoteIdentifier = extractIdentifierFromPrn(created.data.prn);
+
+      const res = await client.delete(remoteIdentifier);
+      await waitForTaskCompletion(res.data.task);
+
+      await assert.rejects(
+        () => client.retrieve(remoteIdentifier),
         (err: unknown) => {
           assert.ok(isAxiosError(err));
           assert.strictEqual(err.response?.status, 404);

--- a/src/api/plugins/rpm/remote.test.ts
+++ b/src/api/plugins/rpm/remote.test.ts
@@ -1,10 +1,11 @@
 import { isAxiosError } from 'axios';
 import assert from 'node:assert/strict';
-import { after, afterEach, before, describe, it } from 'node:test';
+import { after, afterEach, before, beforeEach, describe, it } from 'node:test';
 import {
   extractIdentifierFromPrn,
   testAxiosClient,
   testPulpAPI,
+  waitForTaskCompletion,
 } from '../../test-utils/integration-client.ts';
 import { type RPMRemoteType, createRemoteAPI } from './remote.ts';
 
@@ -240,24 +241,122 @@ describe('Integration: RPM Remote API Client', () => {
         },
       );
     });
+  });
 
-    // NOTE: Verifying if this is expected allowed behaviour for credentials
-    // TODO: Confirm with Pulp Developers
-    it.skip('create() when the url contains embedded credentials returns 400', async () => {
-      const testRpmRemoteName = 'test-rpm-remote-create-invalid-url';
-      const testRpmRemoteInvalidUrl =
-        'https://username:password@example.com/repo/';
+  describe('RPM Remote - update()', () => {
+    const testRpmRemoteName = 'test-rpm-remote-update';
+    const testRpmRemoteUrl = 'https://example.com/repo/';
+    let remotePrn: string | undefined;
+    let remoteHref: string | undefined;
+
+    beforeEach(async () => {
+      const res = await testAxiosClient('remotes/rpm/rpm/', {
+        method: 'POST',
+        data: JSON.stringify({
+          name: testRpmRemoteName,
+          url: testRpmRemoteUrl,
+        }),
+      });
+
+      if (!res.data.prn || !res.data.pulp_href) {
+        throw new Error('Failed to create test remote');
+      }
+
+      remotePrn = res.data.prn;
+      remoteHref = res.data.pulp_href;
+    });
+
+    afterEach(async () => {
+      await testAxiosClient(remoteHref, { method: 'DELETE' });
+      remotePrn = undefined;
+      remoteHref = undefined;
+    });
+
+    it('update() when updating a field with the same value returns 200', async () => {
+      const sameNameValue = 'test-rpm-remote-update';
+      const remoteIdentifier = extractIdentifierFromPrn(remotePrn);
+      const client = createRemoteAPI(testPulpAPI());
+
+      const res = await client.update(remoteIdentifier, {
+        name: sameNameValue,
+      });
+      const expected = await client.retrieve(remoteIdentifier);
+
+      assert.strictEqual(res.status, 200);
+      assert.strictEqual(expected.data.name, sameNameValue);
+    });
+
+    it('update() with a single changed field returns 202 and updates only that field once the task completes', async () => {
+      const remoteIdentifier = extractIdentifierFromPrn(remotePrn);
+      const client = createRemoteAPI(testPulpAPI());
+
+      const res = await client.update(remoteIdentifier, {
+        rate_limit: 12,
+      });
+
+      let actual: RPMRemoteType;
+      assert.strictEqual(res.status, 202);
+      if (res.status === 202 && 'task' in res.data) {
+        await waitForTaskCompletion(res.data.task);
+        actual = (await client.retrieve(remoteIdentifier)).data;
+      }
+
+      assert.strictEqual(actual.rate_limit, 12);
+    });
+
+    it('update() when changing multiple fields returns 202, and all changes are reflected after the task completes', async () => {
+      const remoteIdentifier = extractIdentifierFromPrn(remotePrn);
       const client = createRemoteAPI(testPulpAPI());
       const payload = {
-        name: testRpmRemoteName,
-        url: testRpmRemoteInvalidUrl,
-      } satisfies RPMRemoteType;
+        tls_validation: false,
+        download_concurrency: 3,
+        rate_limit: 3400,
+      } satisfies Partial<RPMRemoteType>;
+
+      const res = await client.update(remoteIdentifier, payload);
+
+      let actual: RPMRemoteType;
+      assert.strictEqual(res.status, 202);
+      if (res.status === 202 && 'task' in res.data) {
+        await waitForTaskCompletion(res.data.task);
+        actual = (await client.retrieve(remoteIdentifier)).data;
+      }
+
+      assert.strictEqual(actual.tls_validation, payload.tls_validation);
+      assert.strictEqual(
+        actual.download_concurrency,
+        payload.download_concurrency,
+      );
+      assert.strictEqual(actual.rate_limit, payload.rate_limit);
+    });
+
+    it('update() when an invalid url scheme is passed returns 400', async () => {
+      const remoteIdentifier = extractIdentifierFromPrn(remotePrn);
+      const client = createRemoteAPI(testPulpAPI());
 
       await assert.rejects(
-        () => client.create(payload),
+        () =>
+          client.update(remoteIdentifier, { url: 'ftp://example.com/repo/' }),
         (err: unknown) => {
           assert.ok(isAxiosError(err));
           assert.strictEqual(err.response?.status, 400);
+          return true;
+        },
+      );
+    });
+
+    it('update() when passed a non-existent identifier returns 404', async () => {
+      const nonExistentRemoteIdentifier = '1234567890';
+      const client = createRemoteAPI(testPulpAPI());
+
+      await assert.rejects(
+        () =>
+          client.update(nonExistentRemoteIdentifier, {
+            rate_limit: 9000,
+          }),
+        (err: unknown) => {
+          assert.ok(isAxiosError(err));
+          assert.strictEqual(err.response?.status, 404);
           return true;
         },
       );

--- a/src/api/plugins/rpm/remote.test.ts
+++ b/src/api/plugins/rpm/remote.test.ts
@@ -1,12 +1,12 @@
 import { isAxiosError } from 'axios';
 import assert from 'node:assert/strict';
-import { after, before, describe, it } from 'node:test';
+import { after, afterEach, before, describe, it } from 'node:test';
 import {
   extractIdentifierFromPrn,
   testAxiosClient,
   testPulpAPI,
 } from '../../test-utils/integration-client.ts';
-import { createRemoteAPI } from './remote.ts';
+import { type RPMRemoteType, createRemoteAPI } from './remote.ts';
 
 describe('Integration: RPM Remote API Client', () => {
   describe('RPM Remote - list()', () => {
@@ -111,6 +111,153 @@ describe('Integration: RPM Remote API Client', () => {
         (err: unknown) => {
           assert.ok(isAxiosError(err));
           assert.strictEqual(err.response?.status, 404);
+          return true;
+        },
+      );
+    });
+  });
+
+  describe('RPM Remote - create()', () => {
+    const testRpmRemoteUrl = 'https://example.com/repo/';
+    let remoteHref: string | undefined;
+
+    afterEach(async () => {
+      if (remoteHref) {
+        await testAxiosClient(remoteHref, { method: 'DELETE' });
+        remoteHref = undefined;
+      }
+    });
+
+    it('create() when giving only the required fields returns the created remote with server default', async () => {
+      const testRpmRemoteName = 'test-rpm-remote-existent-create-minimal';
+      const client = createRemoteAPI(testPulpAPI());
+
+      const res = await client.create({
+        name: testRpmRemoteName,
+        url: testRpmRemoteUrl,
+      });
+      assert.notStrictEqual(res.data.pulp_href, undefined);
+      remoteHref = res.data.pulp_href;
+
+      assert.strictEqual(res.status, 201);
+      assert.strictEqual(res.data.name, testRpmRemoteName);
+      assert.strictEqual(res.data.url, testRpmRemoteUrl);
+      assert.strictEqual(res.data.policy, 'immediate');
+    });
+
+    it('create() when giving additional optional fields returns them back on the created remote', async () => {
+      const testRpmRemoteName = 'test-rpm-remote-existent-create';
+      const client = createRemoteAPI(testPulpAPI());
+      const payload = {
+        name: testRpmRemoteName,
+        url: testRpmRemoteUrl,
+        policy: 'on_demand',
+        tls_validation: false,
+        download_concurrency: 5,
+        sles_auth_token: 'test-token-123',
+      } satisfies RPMRemoteType;
+
+      const res = await client.create(payload);
+      assert.notStrictEqual(res.data.pulp_href, undefined);
+      remoteHref = res.data.pulp_href;
+
+      assert.strictEqual(res.status, 201);
+      assert.strictEqual(res.data.name, payload.name);
+      assert.strictEqual(res.data.url, payload.url);
+      assert.strictEqual(res.data.policy, payload.policy);
+      assert.strictEqual(res.data.tls_validation, payload.tls_validation);
+      assert.strictEqual(
+        res.data.download_concurrency,
+        payload.download_concurrency,
+      );
+      assert.strictEqual(res.data.sles_auth_token, payload.sles_auth_token);
+    });
+
+    it('create() when passed a duplicate name returns 400', async () => {
+      const testRpmRemoteName = 'test-rpm-existent-create-duplicate';
+      const client = createRemoteAPI(testPulpAPI());
+      const payload = {
+        name: testRpmRemoteName,
+        url: testRpmRemoteUrl,
+      } satisfies RPMRemoteType;
+
+      const res = await client.create(payload);
+      assert.notStrictEqual(res.data.pulp_href, undefined);
+      remoteHref = res.data.pulp_href;
+
+      await assert.rejects(
+        () => client.create(payload),
+        (err: unknown) => {
+          assert.ok(isAxiosError(err));
+          assert.strictEqual(err.response?.status, 400);
+          return true;
+        },
+      );
+    });
+
+    it('create() when missing the required name field returns 400', async () => {
+      const client = createRemoteAPI(testPulpAPI());
+
+      await assert.rejects(
+        () => client.create({} as RPMRemoteType),
+        (err: unknown) => {
+          assert.ok(isAxiosError(err));
+          assert.strictEqual(err.response?.status, 400);
+          return true;
+        },
+      );
+    });
+
+    it('create() when missing the required url field returns 400', async () => {
+      const testRpmRemoteName = 'test-rpm-remote-create-missing-url';
+      const client = createRemoteAPI(testPulpAPI());
+
+      await assert.rejects(
+        () => client.create({ name: testRpmRemoteName } as RPMRemoteType),
+        (err: unknown) => {
+          assert.ok(isAxiosError(err));
+          assert.strictEqual(err.response?.status, 400);
+          return true;
+        },
+      );
+    });
+
+    it('create() when an invalid url schema is passed returns 400', async () => {
+      const testRpmRemoteName = 'test-rpm-remote-create-invalid-url';
+      const testRpmRemoteInvalidUrl = 'ftp://example.com/repo/';
+      const client = createRemoteAPI(testPulpAPI());
+      const payload = {
+        name: testRpmRemoteName,
+        url: testRpmRemoteInvalidUrl,
+      } satisfies RPMRemoteType;
+
+      await assert.rejects(
+        () => client.create(payload),
+        (err: unknown) => {
+          assert.ok(isAxiosError(err));
+          assert.strictEqual(err.response?.status, 400);
+          return true;
+        },
+      );
+    });
+
+    // NOTE: Verifying if this is expected allowed behaviour for credentials
+    // TODO: Confirm with Pulp Developers
+    it.skip('create() when the url contains embedded credentials returns 400', async () => {
+      const testRpmRemoteName = 'test-rpm-remote-create-invalid-url';
+      const testRpmRemoteInvalidUrl =
+        'https://username:password@example.com/repo/';
+      const client = createRemoteAPI(testPulpAPI());
+      const payload = {
+        name: testRpmRemoteName,
+        url: testRpmRemoteInvalidUrl,
+      } satisfies RPMRemoteType;
+
+      await assert.rejects(
+        () => client.create(payload),
+        (err: unknown) => {
+          assert.ok(isAxiosError(err));
+          assert.strictEqual(err.response?.status, 400);
           return true;
         },
       );

--- a/src/api/plugins/rpm/remote.test.ts
+++ b/src/api/plugins/rpm/remote.test.ts
@@ -1,55 +1,119 @@
-import { after, before, describe, it } from 'node:test';
+import { isAxiosError } from 'axios';
 import assert from 'node:assert/strict';
+import { after, before, describe, it } from 'node:test';
+import {
+  extractIdentifierFromPrn,
+  testAxiosClient,
+  testPulpAPI,
+} from '../../test-utils/integration-client.ts';
 import { createRemoteAPI } from './remote.ts';
-import { testAxiosClient, testPulpAPI } from '../../test-utils/integration-client.ts';
 
 describe('Integration: RPM Remote API Client', () => {
-    describe('RPM Remote - list()', () => {
-        const testRpmRemoteName = 'test-rpm-remote-existent-list';
-        const testRpmRemoteUrl = 'https://example.com/repo/';
-        let remoteHref: string | undefined;
+  describe('RPM Remote - list()', () => {
+    const testRpmRemoteName = 'test-rpm-remote-existent-list';
+    const testRpmRemoteUrl = 'https://example.com/repo/';
+    let remoteHref: string | undefined;
 
-        before(async () => {
-            const res = await testAxiosClient('remotes/rpm/rpm/', {
-                method: "POST",
-                data: JSON.stringify({ name: testRpmRemoteName, url: testRpmRemoteUrl }),
-            })
-            
-            if (!res.data.pulp_href) {
-                throw new Error('Failed to create test remote')
-            }
+    before(async () => {
+      const res = await testAxiosClient('remotes/rpm/rpm/', {
+        method: 'POST',
+        data: JSON.stringify({
+          name: testRpmRemoteName,
+          url: testRpmRemoteUrl,
+        }),
+      });
 
-            remoteHref = res.data.pulp_href;
-        });
+      if (!res.data.pulp_href) {
+        throw new Error('Failed to create test remote');
+      }
 
-        after(async () => {
-            await testAxiosClient(remoteHref, { method: "DELETE" });
-            remoteHref = undefined;
-        })
-
-        it('list() finds the created remote by exact name', async () => {
-            const client = createRemoteAPI(testPulpAPI());
-
-            const res = await client.list({ name: testRpmRemoteName });
-
-            assert.strictEqual(res.status, 200);
-            assert.strictEqual(res.data.count, 1);
-            assert.strictEqual(res.data.count, res.data.results.length);
-            assert.strictEqual(res.data.results[0].name, testRpmRemoteName);
-            assert.strictEqual(res.data.results[0].pulp_href, remoteHref);
-            assert.strictEqual(res.data.results[0].url, testRpmRemoteUrl);
-        });
-
-        it('list() when passed a non-existent remote name returns empty result', async () => {
-            const nonExistentRemoteName = 'test-rpm-remote-non-existent-list';
-            const client = createRemoteAPI(testPulpAPI());
-
-            const res = await client.list({ name: nonExistentRemoteName });
-
-            assert.strictEqual(res.status, 200);
-            assert.strictEqual(res.data.count, 0);
-            assert.strictEqual(res.data.count, 0);
-            assert.strictEqual(res.data.count, res.data.results.length);
-        })
+      remoteHref = res.data.pulp_href;
     });
+
+    after(async () => {
+      await testAxiosClient(remoteHref, { method: 'DELETE' });
+      remoteHref = undefined;
+    });
+
+    it('list() finds the created remote by exact name', async () => {
+      const client = createRemoteAPI(testPulpAPI());
+
+      const res = await client.list({ name: testRpmRemoteName });
+
+      assert.strictEqual(res.status, 200);
+      assert.strictEqual(res.data.count, 1);
+      assert.strictEqual(res.data.count, res.data.results.length);
+      assert.strictEqual(res.data.results[0].name, testRpmRemoteName);
+      assert.strictEqual(res.data.results[0].pulp_href, remoteHref);
+      assert.strictEqual(res.data.results[0].url, testRpmRemoteUrl);
+    });
+
+    it('list() when passed a non-existent remote name returns empty result', async () => {
+      const nonExistentRemoteName = 'test-rpm-remote-non-existent-list';
+      const client = createRemoteAPI(testPulpAPI());
+
+      const res = await client.list({ name: nonExistentRemoteName });
+
+      assert.strictEqual(res.status, 200);
+      assert.strictEqual(res.data.count, 0);
+      assert.strictEqual(res.data.count, 0);
+      assert.strictEqual(res.data.count, res.data.results.length);
+    });
+  });
+
+  describe('RPM Remote - retrieve()', () => {
+    const testRpmRemoteName = 'test-rpm-remote-existent-retrieve';
+    const testRpmRemoteUrl = 'https://example.com/repo/';
+    let remotePrn: string | undefined;
+    let remoteHref: string | undefined;
+
+    before(async () => {
+      const res = await testAxiosClient('remotes/rpm/rpm/', {
+        method: 'POST',
+        data: JSON.stringify({
+          name: testRpmRemoteName,
+          url: testRpmRemoteUrl,
+        }),
+      });
+
+      if (!res.data.prn || !res.data.pulp_href) {
+        throw new Error('Failed to create test remote');
+      }
+
+      remotePrn = res.data.prn;
+      remoteHref = res.data.pulp_href;
+    });
+
+    after(async () => {
+      await testAxiosClient(remoteHref, { method: 'DELETE' });
+      remotePrn = undefined;
+      remoteHref = undefined;
+    });
+
+    it('retrieve() whe passed correct identifier returns expected remote', async () => {
+      const remoteIdentifier = extractIdentifierFromPrn(remotePrn);
+      const client = createRemoteAPI(testPulpAPI());
+
+      const res = await client.retrieve(remoteIdentifier);
+
+      assert.strictEqual(res.status, 200);
+      assert.strictEqual(res.data.prn, remotePrn);
+      assert.strictEqual(res.data.name, testRpmRemoteName);
+      assert.strictEqual(res.data.url, testRpmRemoteUrl);
+    });
+
+    it('retrieve() when passed a non-existent identifier returns 404', async () => {
+      const nonExistentRemoteIdentifier = '1234567890';
+      const client = createRemoteAPI(testPulpAPI());
+
+      await assert.rejects(
+        () => client.retrieve(nonExistentRemoteIdentifier),
+        (err: unknown) => {
+          assert.ok(isAxiosError(err));
+          assert.strictEqual(err.response?.status, 404);
+          return true;
+        },
+      );
+    });
+  });
 });

--- a/src/api/plugins/rpm/remote.ts
+++ b/src/api/plugins/rpm/remote.ts
@@ -1,0 +1,39 @@
+import type { AxiosResponse } from 'axios';
+import type {
+  GenericRemote,
+  GenericRemoteFilterParams,
+  PaginatedResponse,
+} from 'src/api/common';
+import type { PulpAPI } from 'src/api/pulp';
+
+/**
+ * RPM Remote Type.
+ *
+ * @see https://github.com/pulp/pulp_rpm/blob/dc333a99db6c44d70d6103540cb592f6e55a8682/pulp_rpm/app/serializers/repository.py#L392
+ */
+interface RPMRemoteType extends GenericRemote {
+  sles_auth_token: string | null;
+}
+
+interface RPMRemoteClient {
+  list: (
+    params?: GenericRemoteFilterParams,
+  ) => Promise<AxiosResponse<PaginatedResponse<RPMRemoteType>>>;
+  // retrieve
+  // create
+  // update
+  // delete
+}
+
+/**
+ * RPM Remote API Client
+ * @param {PulpAPI} base
+ * @returns {RPMRemoteClient}
+ */
+function createRemoteAPI(base: PulpAPI): RPMRemoteClient {
+  return {
+    list: (params?) => base.list(`remotes/rpm/rpm/`, params),
+  };
+}
+
+export { createRemoteAPI };

--- a/src/api/plugins/rpm/remote.ts
+++ b/src/api/plugins/rpm/remote.ts
@@ -1,5 +1,6 @@
 import type { AxiosResponse } from 'axios';
 import type {
+  DispatchedTaskResponse,
   GenericRemote,
   GenericRemoteFilterParams,
   PaginatedResponse,
@@ -21,7 +22,10 @@ interface RPMRemoteClient {
   ) => Promise<AxiosResponse<PaginatedResponse<RPMRemoteType>>>;
   retrieve: (id: string) => Promise<AxiosResponse<RPMRemoteType>>;
   create: (data: RPMRemoteType) => Promise<AxiosResponse<RPMRemoteType>>;
-  // update
+  update: (
+    id: string,
+    data: Partial<RPMRemoteType>,
+  ) => Promise<AxiosResponse<RPMRemoteType | DispatchedTaskResponse>>;
   // delete
 }
 
@@ -35,6 +39,7 @@ function createRemoteAPI(base: PulpAPI): RPMRemoteClient {
     list: (params?) => base.list(`remotes/rpm/rpm/`, params),
     retrieve: (id) => base.http.get(`remotes/rpm/rpm/${id}/`),
     create: (data) => base.http.post(`remotes/rpm/rpm/`, data),
+    update: (id, data) => base.http.patch(`remotes/rpm/rpm/${id}/`, data),
   };
 }
 

--- a/src/api/plugins/rpm/remote.ts
+++ b/src/api/plugins/rpm/remote.ts
@@ -19,8 +19,8 @@ interface RPMRemoteClient {
   list: (
     params?: GenericRemoteFilterParams,
   ) => Promise<AxiosResponse<PaginatedResponse<RPMRemoteType>>>;
-  // retrieve
-  // create
+  retrieve: (id: string) => Promise<AxiosResponse<RPMRemoteType>>;
+  // create: (data: RPMRemoteType) => Promise<AxiosResponse<RPMRemoteType>>;
   // update
   // delete
 }
@@ -33,6 +33,7 @@ interface RPMRemoteClient {
 function createRemoteAPI(base: PulpAPI): RPMRemoteClient {
   return {
     list: (params?) => base.list(`remotes/rpm/rpm/`, params),
+    retrieve: (id) => base.http.get(`remotes/rpm/rpm/${id}/`),
   };
 }
 

--- a/src/api/plugins/rpm/remote.ts
+++ b/src/api/plugins/rpm/remote.ts
@@ -12,7 +12,7 @@ import type { PulpAPI } from 'src/api/pulp';
  * @see https://github.com/pulp/pulp_rpm/blob/dc333a99db6c44d70d6103540cb592f6e55a8682/pulp_rpm/app/serializers/repository.py#L392
  */
 interface RPMRemoteType extends GenericRemote {
-  sles_auth_token: string | null;
+  sles_auth_token?: string | null;
 }
 
 interface RPMRemoteClient {
@@ -20,7 +20,7 @@ interface RPMRemoteClient {
     params?: GenericRemoteFilterParams,
   ) => Promise<AxiosResponse<PaginatedResponse<RPMRemoteType>>>;
   retrieve: (id: string) => Promise<AxiosResponse<RPMRemoteType>>;
-  // create: (data: RPMRemoteType) => Promise<AxiosResponse<RPMRemoteType>>;
+  create: (data: RPMRemoteType) => Promise<AxiosResponse<RPMRemoteType>>;
   // update
   // delete
 }
@@ -34,7 +34,9 @@ function createRemoteAPI(base: PulpAPI): RPMRemoteClient {
   return {
     list: (params?) => base.list(`remotes/rpm/rpm/`, params),
     retrieve: (id) => base.http.get(`remotes/rpm/rpm/${id}/`),
+    create: (data) => base.http.post(`remotes/rpm/rpm/`, data),
   };
 }
 
 export { createRemoteAPI };
+export type { RPMRemoteType };

--- a/src/api/plugins/rpm/remote.ts
+++ b/src/api/plugins/rpm/remote.ts
@@ -35,6 +35,8 @@ interface RPMRemoteClient {
  * RPM Remote API Client
  * @param {PulpAPI} base
  * @returns {RPMRemoteClient}
+ * 
+ * @see https://github.com/pulp/pulp_rpm/blob/dc333a99db6c44d70d6103540cb592f6e55a8682/pulp_rpm/app/viewsets/repository.py#L361
  */
 function createRemoteAPI(base: PulpAPI): RPMRemoteClient {
   return {

--- a/src/api/plugins/rpm/remote.ts
+++ b/src/api/plugins/rpm/remote.ts
@@ -35,7 +35,7 @@ interface RPMRemoteClient {
  * RPM Remote API Client
  * @param {PulpAPI} base
  * @returns {RPMRemoteClient}
- * 
+ *
  * @see https://github.com/pulp/pulp_rpm/blob/dc333a99db6c44d70d6103540cb592f6e55a8682/pulp_rpm/app/viewsets/repository.py#L361
  */
 function createRemoteAPI(base: PulpAPI): RPMRemoteClient {

--- a/src/api/plugins/rpm/remote.ts
+++ b/src/api/plugins/rpm/remote.ts
@@ -16,6 +16,8 @@ interface RPMRemoteType extends GenericRemote {
   sles_auth_token?: string | null;
 }
 
+// FIXME: Move AxiosResponse type to PulpAPI Base Class.
+// NOTE: The FIXME implementation is not easy as to avoid major type issues with legacy API calls.
 interface RPMRemoteClient {
   list: (
     params?: GenericRemoteFilterParams,
@@ -26,7 +28,7 @@ interface RPMRemoteClient {
     id: string,
     data: Partial<RPMRemoteType>,
   ) => Promise<AxiosResponse<RPMRemoteType | DispatchedTaskResponse>>;
-  // delete
+  delete: (id: string) => Promise<AxiosResponse<DispatchedTaskResponse>>;
 }
 
 /**
@@ -40,6 +42,7 @@ function createRemoteAPI(base: PulpAPI): RPMRemoteClient {
     retrieve: (id) => base.http.get(`remotes/rpm/rpm/${id}/`),
     create: (data) => base.http.post(`remotes/rpm/rpm/`, data),
     update: (id, data) => base.http.patch(`remotes/rpm/rpm/${id}/`, data),
+    delete: (id) => base.http.delete(`remotes/rpm/rpm/${id}/`),
   };
 }
 

--- a/src/api/plugins/rpm/repository.test.ts
+++ b/src/api/plugins/rpm/repository.test.ts
@@ -4,6 +4,7 @@ import { after, afterEach, before, beforeEach, describe, it } from 'node:test';
 import {
   testAxiosClient,
   testPulpAPI,
+  waitForTaskCompletion,
 } from '../../test-utils/integration-client.ts';
 import {
   type RPMRepositoryType,
@@ -254,7 +255,22 @@ describe('Integration: RPM Repository API Client', () => {
       repositoryPrn = undefined;
     });
 
-    it('update() with a single changed field updates only that field', async () => {
+    it('update() when updating a field with the same value returns 200', async () => {
+      const sameNameValue = 'test-rpm-repo-update';
+      const repositoryIdentifier = repositoryPrn.split(':', 3)[2];
+      assert.strictEqual(typeof repositoryIdentifier, 'string');
+      const client = createRepositoryAPI(testPulpAPI());
+
+      const res = await client.update(repositoryIdentifier, {
+        name: sameNameValue,
+      });
+      const expected = await client.retrieve(repositoryIdentifier);
+
+      assert.strictEqual(res.status, 200);
+      assert.strictEqual(expected.data.name, sameNameValue);
+    });
+
+    it('update() with a single changed field returns 202 and updates only that field once the task completes', async () => {
       const repositoryIdentifier = repositoryPrn.split(':', 3)[2];
       assert.strictEqual(typeof repositoryIdentifier, 'string');
       const client = createRepositoryAPI(testPulpAPI());
@@ -262,13 +278,20 @@ describe('Integration: RPM Repository API Client', () => {
       const res = await client.update(repositoryIdentifier, {
         description: 'Updated description',
       });
-      const expected = await client.retrieve(repositoryIdentifier);
+
+      let actual: RPMRepositoryType;
+      assert.strictEqual(res.status, 202);
+      if (res.status === 202) {
+        // TODO: Fix broken return type on Update
+        await waitForTaskCompletion(res.data.task);
+        actual = (await client.retrieve(repositoryIdentifier)).data;
+      }
 
       assert.strictEqual(res.status, 202);
-      assert.strictEqual(expected.data.description, 'Updated description');
+      assert.strictEqual(actual.description, 'Updated description');
     });
 
-    it('update() with multiple changed fields updates all associated', async () => {
+    it('update() when changing multiple fields returns 202, and all changes are reflected after the task completes', async () => {
       const repositoryIdentifier = repositoryPrn.split(':', 3)[2];
       assert.strictEqual(typeof repositoryPrn, 'string');
       const client = createRepositoryAPI(testPulpAPI());
@@ -280,13 +303,19 @@ describe('Integration: RPM Repository API Client', () => {
       } satisfies Partial<RPMRepositoryUpsertType>;
 
       const res = await client.update(repositoryIdentifier, payload);
-      const actual = await client.retrieve(repositoryIdentifier);
 
+      let actual: RPMRepositoryType;
       assert.strictEqual(res.status, 202);
-      assert.strictEqual(actual.data.autopublish, true);
-      assert.strictEqual(actual.data.retain_package_versions, 5);
-      assert.strictEqual(actual.data.checksum_type, 'sha256');
-      assert.strictEqual(actual.data.compression_type, 'zstd');
+      if (res.status === 202) {
+        // TODO: Fix broken return type on Update
+        await waitForTaskCompletion(res.data.task);
+        actual = (await client.retrieve(repositoryIdentifier)).data;
+      }
+
+      assert.strictEqual(actual.autopublish, true);
+      assert.strictEqual(actual.retain_package_versions, 5);
+      assert.strictEqual(actual.checksum_type, 'sha256');
+      assert.strictEqual(actual.compression_type, 'zstd');
     });
 
     it('update() when a not allowed checksum_type is passed returns 400', async () => {
@@ -316,6 +345,59 @@ describe('Integration: RPM Repository API Client', () => {
           client.update(nonExistentRepositoryIdentifier, {
             description: 'This will not update',
           }),
+        (err: unknown) => {
+          assert.ok(isAxiosError(err));
+          assert.strictEqual(err.response?.status, 404);
+          return true;
+        },
+      );
+    });
+  });
+
+  describe('RPM Repository - delete()', () => {
+    it('delete() returns 202 and dispatches a task', async () => {
+      const created = await testAxiosClient('repositories/rpm/rpm/', {
+        method: 'POST',
+        data: JSON.stringify({ name: 'test-rpm-repo-delete-valid' }),
+      });
+      const repositoryIdentifier = created.data.prn.split(':', 3)[2];
+      const client = createRepositoryAPI(testPulpAPI());
+
+      const res = await client.delete(repositoryIdentifier);
+
+      assert.strictEqual(res.status, 202);
+      // TODO: Fix broken return type on Delete
+      assert.notStrictEqual(res.data.task, undefined);
+    });
+
+    it('delete() when passed a non-existent identifier returns 404', async () => {
+      const nonExistentRepositoryIdentifier = '1234567890';
+      const client = createRepositoryAPI(testPulpAPI());
+
+      await assert.rejects(
+        () => client.delete(nonExistentRepositoryIdentifier),
+        (err: unknown) => {
+          assert.ok(isAxiosError(err));
+          assert.strictEqual(err.response?.status, 404);
+          return true;
+        },
+      );
+    });
+
+    it('delete() removes the repository once the dispatched task completes', async () => {
+      const created = await testAxiosClient('repositories/rpm/rpm/', {
+        method: 'POST',
+        data: JSON.stringify({ name: 'test-rpm-repo-delete-completion' }),
+      });
+      const repositoryIdentifier = created.data.prn.split(':', 3)[2];
+      const client = createRepositoryAPI(testPulpAPI());
+
+      const res = await client.delete(repositoryIdentifier);
+      // TODO: Fix broken return type on Delete
+      await waitForTaskCompletion(res.data.task);
+
+      await assert.rejects(
+        () => client.retrieve(repositoryIdentifier),
         (err: unknown) => {
           assert.ok(isAxiosError(err));
           assert.strictEqual(err.response?.status, 404);

--- a/src/api/plugins/rpm/repository.test.ts
+++ b/src/api/plugins/rpm/repository.test.ts
@@ -1,0 +1,91 @@
+import assert from 'node:assert/strict';
+import { after, before, describe, it } from 'node:test';
+import type { PulpAPI } from 'src/api/pulp';
+import { createRepositoryAPI } from './repository.ts';
+
+const baseUrl: string =
+  process.env.PULP_BASE_URL ?? 'http://localhost:8080/pulp/api/v3/';
+const testUsername: string = process.env.PULP_USERNAME ?? 'admin';
+const testPassword: string = process.env.PULP_PASSWORD ?? 'admin';
+const authorization: string =
+  'Basic ' + Buffer.from(`${testUsername}:${testPassword}`).toString('base64');
+
+async function testFetch(
+  path: string,
+  init: RequestInit = {},
+): Promise<unknown> {
+  const url: URL = new URL(path, baseUrl);
+  const res: Response = await fetch(url, {
+    ...init,
+    headers: {
+      authorization,
+      'content-type': 'application/json',
+      ...init.headers,
+    },
+  });
+
+  return res.json();
+}
+
+function buildQueryParams(params?: Record<string, unknown>): string {
+  const search = new URLSearchParams();
+
+  for (const [key, value] of Object.entries(params ?? {})) {
+    if (value !== undefined) {
+      search.set(key, String(value));
+    }
+  }
+
+  const queryString = search.toString();
+  return queryString ? `?${queryString}` : '';
+}
+
+function testClient(): PulpAPI {
+  return {
+    list: (url: string, params?: Record<string, unknown>) =>
+      testFetch(`${url}${buildQueryParams(params)}`).then((data) => ({ data })),
+  } as unknown as PulpAPI;
+}
+
+describe('Integration: RPM Repository API Client', () => {
+  let createdHref: string;
+
+  before(async () => {
+    const repo = await testFetch('repositories/rpm/rpm/', {
+      method: 'POST',
+      body: JSON.stringify({ name: 'test-rpm-repo-existent' }),
+    });
+    // @ts-ignore
+    createdHref = repo.pulp_href;
+
+    if (!createdHref) {
+        throw new Error()
+    }
+  });
+
+  after(async () => {
+    await testFetch(createdHref, {
+      method: 'DELETE',
+    });
+  });
+
+  it('list() finds the created repository by exact name', async () => {
+    const client = createRepositoryAPI(testClient());
+
+    const res = await client.list({ name: 'test-rpm-repo-existent' });
+
+    assert.strictEqual(res.data.count, 1);
+    assert.strictEqual(res.data.count, res.data.results.length);
+    assert.strictEqual(res.data.results[0].name, 'test-rpm-repo-existent');
+    assert.strictEqual(res.data.results[0].pulp_href, createdHref);
+  });
+
+  it('list() when passed a non-existent repository name returns empty results array', async () => {
+    const client = createRepositoryAPI(testClient());
+
+    const res = await client.list({ name: 'test-rpm-repo-non-existent' });
+
+    assert.strictEqual(res.data.count, 0);
+    assert.strictEqual(res.data.count, res.data.results.length);
+  });
+});

--- a/src/api/plugins/rpm/repository.test.ts
+++ b/src/api/plugins/rpm/repository.test.ts
@@ -23,9 +23,8 @@ describe('Integration: RPM Repository API Client', () => {
         data: JSON.stringify({ name: testRpmRepoName }),
       });
 
-      // TODO: Update Error Message and Error Check
       if (!res.data.pulp_href) {
-        throw new Error();
+        throw new Error('Failed to create test repository');
       }
 
       repositoryHref = res.data.pulp_href;
@@ -71,9 +70,8 @@ describe('Integration: RPM Repository API Client', () => {
         data: JSON.stringify({ name: testRpmRepoName }),
       });
 
-      // TODO: Update Error Message and Error Check
       if (!res.data.prn || !res.data.pulp_href) {
-        throw new Error();
+        throw new Error('Failed to create test repository');
       }
 
       repositoryPrn = res.data.prn;
@@ -240,9 +238,8 @@ describe('Integration: RPM Repository API Client', () => {
         data: JSON.stringify({ name: 'test-rpm-repo-update' }),
       });
 
-      // TODO: Update Error Message and Error Check
       if (!res.data.prn || !res.data.pulp_href) {
-        throw new Error();
+        throw new Error('Failed to create test repository');
       }
 
       repositoryHref = res.data.pulp_href;
@@ -281,8 +278,7 @@ describe('Integration: RPM Repository API Client', () => {
 
       let actual: RPMRepositoryType;
       assert.strictEqual(res.status, 202);
-      if (res.status === 202) {
-        // TODO: Fix broken return type on Update
+      if (res.status === 202 && 'task' in res.data) {
         await waitForTaskCompletion(res.data.task);
         actual = (await client.retrieve(repositoryIdentifier)).data;
       }
@@ -306,8 +302,7 @@ describe('Integration: RPM Repository API Client', () => {
 
       let actual: RPMRepositoryType;
       assert.strictEqual(res.status, 202);
-      if (res.status === 202) {
-        // TODO: Fix broken return type on Update
+      if (res.status === 202 && 'task' in res.data) {
         await waitForTaskCompletion(res.data.task);
         actual = (await client.retrieve(repositoryIdentifier)).data;
       }
@@ -366,7 +361,6 @@ describe('Integration: RPM Repository API Client', () => {
       const res = await client.delete(repositoryIdentifier);
 
       assert.strictEqual(res.status, 202);
-      // TODO: Fix broken return type on Delete
       assert.notStrictEqual(res.data.task, undefined);
     });
 
@@ -393,7 +387,6 @@ describe('Integration: RPM Repository API Client', () => {
       const client = createRepositoryAPI(testPulpAPI());
 
       const res = await client.delete(repositoryIdentifier);
-      // TODO: Fix broken return type on Delete
       await waitForTaskCompletion(res.data.task);
 
       await assert.rejects(

--- a/src/api/plugins/rpm/repository.test.ts
+++ b/src/api/plugins/rpm/repository.test.ts
@@ -1,91 +1,110 @@
+import { isAxiosError } from 'axios';
 import assert from 'node:assert/strict';
 import { after, before, describe, it } from 'node:test';
-import type { PulpAPI } from 'src/api/pulp';
+import {
+  testAxiosClient,
+  testPulpAPI,
+} from 'src/api/test-utils/integration-client.ts';
 import { createRepositoryAPI } from './repository.ts';
 
-const baseUrl: string =
-  process.env.PULP_BASE_URL ?? 'http://localhost:8080/pulp/api/v3/';
-const testUsername: string = process.env.PULP_USERNAME ?? 'admin';
-const testPassword: string = process.env.PULP_PASSWORD ?? 'admin';
-const authorization: string =
-  'Basic ' + Buffer.from(`${testUsername}:${testPassword}`).toString('base64');
-
-async function testFetch(
-  path: string,
-  init: RequestInit = {},
-): Promise<unknown> {
-  const url: URL = new URL(path, baseUrl);
-  const res: Response = await fetch(url, {
-    ...init,
-    headers: {
-      authorization,
-      'content-type': 'application/json',
-      ...init.headers,
-    },
-  });
-
-  return res.json();
-}
-
-function buildQueryParams(params?: Record<string, unknown>): string {
-  const search = new URLSearchParams();
-
-  for (const [key, value] of Object.entries(params ?? {})) {
-    if (value !== undefined) {
-      search.set(key, String(value));
-    }
-  }
-
-  const queryString = search.toString();
-  return queryString ? `?${queryString}` : '';
-}
-
-function testClient(): PulpAPI {
-  return {
-    list: (url: string, params?: Record<string, unknown>) =>
-      testFetch(`${url}${buildQueryParams(params)}`).then((data) => ({ data })),
-  } as unknown as PulpAPI;
-}
-
 describe('Integration: RPM Repository API Client', () => {
-  let createdHref: string;
+  describe('RPM Repository - list()', () => {
+    const testRpmRepoName = 'test-rpm-repo-existent-list';
+    let repositoryHref: string;
 
-  before(async () => {
-    const repo = await testFetch('repositories/rpm/rpm/', {
-      method: 'POST',
-      body: JSON.stringify({ name: 'test-rpm-repo-existent' }),
+    before(async () => {
+      const res = await testAxiosClient('repositories/rpm/rpm/', {
+        method: 'POST',
+        data: JSON.stringify({ name: testRpmRepoName }),
+      });
+
+      // TODO: Update Error Message and Error Check
+      if (res.status === 500 || !res.data.pulp_href) {
+        throw new Error();
+      }
+
+      repositoryHref = res.data.pulp_href;
     });
-    // @ts-ignore
-    createdHref = repo.pulp_href;
 
-    if (!createdHref) {
-        throw new Error()
-    }
-  });
+    after(async () => {
+      await testAxiosClient(repositoryHref, { method: 'DELETE' });
+    });
 
-  after(async () => {
-    await testFetch(createdHref, {
-      method: 'DELETE',
+    it('list() find the created repository by exact name', async () => {
+      const client = createRepositoryAPI(testPulpAPI());
+
+      const res = await client.list({ name: testRpmRepoName });
+
+      assert.strictEqual(res.status, 200);
+      assert.strictEqual(res.data.count, 1);
+      assert.strictEqual(res.data.count, res.data.results.length);
+      assert.strictEqual(res.data.results[0].name, testRpmRepoName);
+      assert.strictEqual(res.data.results[0].pulp_href, repositoryHref);
+    });
+
+    it('list() when passed a non-existent repository name returns empty result', async () => {
+      const nonExistentRepositoryName = 'test-rpm-repo-non-existent-list';
+      const client = createRepositoryAPI(testPulpAPI());
+
+      const res = await client.list({ name: nonExistentRepositoryName });
+
+      assert.strictEqual(res.status, 200);
+      assert.strictEqual(res.data.count, 0);
+      assert.strictEqual(res.data.results.length, 0);
+      assert.strictEqual(res.data.count, res.data.results.length);
     });
   });
 
-  it('list() finds the created repository by exact name', async () => {
-    const client = createRepositoryAPI(testClient());
+  describe('RPM Repository - retrieve()', () => {
+    const testRpmRepoName = 'test-rpm-repo-existent-retrieve';
+    let repositoryPrn: string;
+    let repositoryHref: string;
 
-    const res = await client.list({ name: 'test-rpm-repo-existent' });
+    before(async () => {
+      const res = await testAxiosClient('repositories/rpm/rpm/', {
+        method: 'POST',
+        data: JSON.stringify({ name: testRpmRepoName }),
+      });
 
-    assert.strictEqual(res.data.count, 1);
-    assert.strictEqual(res.data.count, res.data.results.length);
-    assert.strictEqual(res.data.results[0].name, 'test-rpm-repo-existent');
-    assert.strictEqual(res.data.results[0].pulp_href, createdHref);
-  });
+      // TODO: Update Error Message and Error Check
+      if (res.status === 500 || !res.data.prn) {
+        throw new Error();
+      }
 
-  it('list() when passed a non-existent repository name returns empty results array', async () => {
-    const client = createRepositoryAPI(testClient());
+      repositoryPrn = res.data.prn;
+      repositoryHref = res.data.pulp_href;
+    });
 
-    const res = await client.list({ name: 'test-rpm-repo-non-existent' });
+    after(async () => {
+      await testAxiosClient(repositoryHref, { method: 'DELETE' });
+    });
 
-    assert.strictEqual(res.data.count, 0);
-    assert.strictEqual(res.data.count, res.data.results.length);
+    it('retrieve() when passed correct identifier returns expected repository', async () => {
+      const repositoryIdentifier = repositoryPrn.split(':', 3)[2];
+      assert.strictEqual(typeof repositoryIdentifier, 'string');
+
+      const client = createRepositoryAPI(testPulpAPI());
+
+      const res = await client.retrieve(repositoryIdentifier);
+
+      assert.strictEqual(res.status, 200);
+      assert.strictEqual(res.data.prn, repositoryPrn);
+      assert.strictEqual(res.data.name, testRpmRepoName);
+    });
+
+    it('retrieve() when passed an non-existent identifier returns empty object', async () => {
+      const nonExistentRepositoryIdentifier = '1234567890';
+
+      const client = createRepositoryAPI(testPulpAPI());
+
+      await assert.rejects(
+        () => client.retrieve(nonExistentRepositoryIdentifier),
+        (err: unknown) => {
+          assert.ok(isAxiosError(err));
+          assert.strictEqual(err.response?.status, 404);
+          return true;
+        },
+      );
+    });
   });
 });

--- a/src/api/plugins/rpm/repository.test.ts
+++ b/src/api/plugins/rpm/repository.test.ts
@@ -1,11 +1,15 @@
 import { isAxiosError } from 'axios';
 import assert from 'node:assert/strict';
-import { after, before, describe, it } from 'node:test';
+import { after, afterEach, before, beforeEach, describe, it } from 'node:test';
 import {
   testAxiosClient,
   testPulpAPI,
-} from 'src/api/test-utils/integration-client.ts';
-import { createRepositoryAPI } from './repository.ts';
+} from '../../test-utils/integration-client.ts';
+import {
+  type RPMRepositoryType,
+  type RPMRepositoryUpsertType,
+  createRepositoryAPI,
+} from './repository.ts';
 
 describe('Integration: RPM Repository API Client', () => {
   describe('RPM Repository - list()', () => {
@@ -19,7 +23,7 @@ describe('Integration: RPM Repository API Client', () => {
       });
 
       // TODO: Update Error Message and Error Check
-      if (res.status === 500 || !res.data.pulp_href) {
+      if (!res.data.pulp_href) {
         throw new Error();
       }
 
@@ -67,7 +71,7 @@ describe('Integration: RPM Repository API Client', () => {
       });
 
       // TODO: Update Error Message and Error Check
-      if (res.status === 500 || !res.data.prn) {
+      if (!res.data.prn || !res.data.pulp_href) {
         throw new Error();
       }
 
@@ -99,6 +103,219 @@ describe('Integration: RPM Repository API Client', () => {
 
       await assert.rejects(
         () => client.retrieve(nonExistentRepositoryIdentifier),
+        (err: unknown) => {
+          assert.ok(isAxiosError(err));
+          assert.strictEqual(err.response?.status, 404);
+          return true;
+        },
+      );
+    });
+  });
+
+  describe('RPM Repository - create()', () => {
+    let repositoryHref: string | undefined;
+
+    afterEach(async () => {
+      if (repositoryHref) {
+        await testAxiosClient(repositoryHref, { method: 'DELETE' });
+        repositoryHref = undefined;
+      }
+    });
+
+    it('create() when giving only the repository name returns with the created repository defaults', async () => {
+      const testRpmRepoName = 'test-rpm-repo-existent-create-minimal';
+      const client = createRepositoryAPI(testPulpAPI());
+
+      const res = await client.create({ name: testRpmRepoName });
+      assert.notStrictEqual(res.data.pulp_href, undefined);
+      repositoryHref = res.data.pulp_href;
+
+      assert.strictEqual(res.status, 201);
+      assert.strictEqual(res.data.name, testRpmRepoName);
+      assert.strictEqual(res.data.autopublish, false);
+      assert.strictEqual(res.data.retain_package_versions, 0);
+      assert.strictEqual(res.data.checksum_type, null);
+    });
+
+    it('create() when giving additional data fields from required returns them back on created repository', async () => {
+      const testRpmRepoName = 'test-rpm-existent-create-full';
+      const client = createRepositoryAPI(testPulpAPI());
+      const payload = {
+        name: testRpmRepoName,
+        autopublish: true,
+        retain_package_versions: 3,
+        checksum_type: 'sha256',
+        description: 'This is a test description',
+      } satisfies RPMRepositoryType;
+
+      const res = await client.create(payload);
+      assert.notStrictEqual(res.data.pulp_href, repositoryHref);
+      repositoryHref = res.data.pulp_href;
+
+      assert.strictEqual(res.status, 201);
+      assert.strictEqual(res.data.autopublish, true);
+      assert.strictEqual(res.data.name, testRpmRepoName);
+      assert.strictEqual(res.data.retain_package_versions, 3);
+      assert.strictEqual(res.data.checksum_type, 'sha256');
+      assert.strictEqual(res.data.description, 'This is a test description');
+    });
+
+    it('create() when passed with a duplicate name returns 400', async () => {
+      const testRpmRepoName = 'test-rpm-existent-create-duplicate';
+      const client = createRepositoryAPI(testPulpAPI());
+
+      const res = await client.create({ name: testRpmRepoName });
+      assert.notStrictEqual(res.data.pulp_href, undefined);
+      repositoryHref = res.data.pulp_href;
+
+      await assert.rejects(
+        () => client.create({ name: testRpmRepoName }),
+        (err: unknown) => {
+          assert.ok(isAxiosError(err));
+          assert.strictEqual(err.response?.status, 400);
+          return true;
+        },
+      );
+    });
+
+    it('create() when missing the required name field returns 400', async () => {
+      const client = createRepositoryAPI(testPulpAPI());
+
+      await assert.rejects(
+        () => client.create({} as RPMRepositoryUpsertType),
+        (err: unknown) => {
+          assert.ok(isAxiosError(err));
+          assert.strictEqual(err.response?.status, 400);
+          return true;
+        },
+      );
+    });
+
+    it('create() when an invalid field is passed returns 400', async () => {
+      const testRpmRepoName = 'test-rpm-existent-create-duplicate';
+      const client = createRepositoryAPI(testPulpAPI());
+      const invalidPayload = {
+        name: testRpmRepoName,
+        compression_type:
+          'I am a test' as RPMRepositoryUpsertType['compression_type'],
+      };
+
+      await assert.rejects(
+        () => client.create(invalidPayload),
+        (err: unknown) => {
+          assert.ok(isAxiosError(err));
+          assert.strictEqual(err.response?.status, 400);
+          return true;
+        },
+      );
+    });
+
+    it('create() when a not allowed checksum_type is passed returns 400', async () => {
+      const testRpmRepoName = 'test-rpm-existent-create-duplicate';
+      const client = createRepositoryAPI(testPulpAPI());
+      const invalidPayload = {
+        name: testRpmRepoName,
+        checksum_type: 'md5' as RPMRepositoryUpsertType['checksum_type'],
+      };
+
+      await assert.rejects(
+        () => client.create(invalidPayload),
+        (err: unknown) => {
+          assert.ok(isAxiosError(err));
+          assert.strictEqual(err.response?.status, 400);
+          return true;
+        },
+      );
+    });
+  });
+
+  describe('RPM Repository - update()', () => {
+    let repositoryHref: string | undefined;
+    let repositoryPrn: string | undefined;
+
+    beforeEach(async () => {
+      const res = await testAxiosClient('repositories/rpm/rpm/', {
+        method: 'POST',
+        data: JSON.stringify({ name: 'test-rpm-repo-update' }),
+      });
+
+      // TODO: Update Error Message and Error Check
+      if (!res.data.prn || !res.data.pulp_href) {
+        throw new Error();
+      }
+
+      repositoryHref = res.data.pulp_href;
+      repositoryPrn = res.data.prn;
+    });
+
+    afterEach(async () => {
+      await testAxiosClient(repositoryHref, { method: 'DELETE' });
+      repositoryHref = undefined;
+      repositoryPrn = undefined;
+    });
+
+    it('update() with a single changed field updates only that field', async () => {
+      const repositoryIdentifier = repositoryPrn.split(':', 3)[2];
+      assert.strictEqual(typeof repositoryIdentifier, 'string');
+      const client = createRepositoryAPI(testPulpAPI());
+
+      const res = await client.update(repositoryIdentifier, {
+        description: 'Updated description',
+      });
+      const expected = await client.retrieve(repositoryIdentifier);
+
+      assert.strictEqual(res.status, 202);
+      assert.strictEqual(expected.data.description, 'Updated description');
+    });
+
+    it('update() with multiple changed fields updates all associated', async () => {
+      const repositoryIdentifier = repositoryPrn.split(':', 3)[2];
+      assert.strictEqual(typeof repositoryPrn, 'string');
+      const client = createRepositoryAPI(testPulpAPI());
+      const payload = {
+        autopublish: true,
+        retain_package_versions: 5,
+        checksum_type: 'sha256',
+        compression_type: 'zstd',
+      } satisfies Partial<RPMRepositoryUpsertType>;
+
+      const res = await client.update(repositoryIdentifier, payload);
+      const actual = await client.retrieve(repositoryIdentifier);
+
+      assert.strictEqual(res.status, 202);
+      assert.strictEqual(actual.data.autopublish, true);
+      assert.strictEqual(actual.data.retain_package_versions, 5);
+      assert.strictEqual(actual.data.checksum_type, 'sha256');
+      assert.strictEqual(actual.data.compression_type, 'zstd');
+    });
+
+    it('update() when a not allowed checksum_type is passed returns 400', async () => {
+      const repositoryIdentifier = repositoryPrn.split(':', 3)[2];
+      assert.strictEqual(typeof repositoryPrn, 'string');
+      const client = createRepositoryAPI(testPulpAPI());
+      const invalidPayload = {
+        checksum_type: 'sha1' as RPMRepositoryUpsertType['checksum_type'],
+      };
+
+      await assert.rejects(
+        () => client.update(repositoryIdentifier, invalidPayload),
+        (err: unknown) => {
+          assert.ok(isAxiosError(err));
+          assert.strictEqual(err.response?.status, 400);
+          return true;
+        },
+      );
+    });
+
+    it('update() when passed a non-existent identifier returns 404', async () => {
+      const nonExistentRepositoryIdentifier = '1234567890';
+      const client = createRepositoryAPI(testPulpAPI());
+
+      await assert.rejects(
+        () =>
+          client.update(nonExistentRepositoryIdentifier, {
+            description: 'This will not update',
+          }),
         (err: unknown) => {
           assert.ok(isAxiosError(err));
           assert.strictEqual(err.response?.status, 404);

--- a/src/api/plugins/rpm/repository.ts
+++ b/src/api/plugins/rpm/repository.ts
@@ -39,7 +39,7 @@ interface RPMRepositoryType extends GenericRepository {
 
 /**
  * RPM Create / Update Type.
- * 
+ *
  * @see https://github.com/pulp/pulp_rpm/blob/dc333a99db6c44d70d6103540cb592f6e55a8682/pulp_rpm/app/serializers/repository.py#L326
  */
 interface RPMRepositoryUpsertType extends Omit<
@@ -49,7 +49,8 @@ interface RPMRepositoryUpsertType extends Omit<
   checksum_type?: RPMAllowedUpsertChecksumsType | null;
 }
 
-// FIXME: Move AxiosResponse type to PulpAPI Base Class.
+// FIXME: Move AxiosResponse type to PulpAPI Base Class. 
+// NOTE: The FIXME implementation is not easy as to avoid major type issues with legacy API calls.
 interface RPMRepositoryClient {
   list: (
     params?: GenericRepositoryFilterParams,
@@ -61,10 +62,10 @@ interface RPMRepositoryClient {
   update: (
     id: string,
     data: Partial<RPMRepositoryUpsertType>,
-    // TODO: Update Reponse Type
+    // TODO: Update Response Type to union of Upsert Type & Task Type
   ) => Promise<AxiosResponse<RPMRepositoryUpsertType>>;
-  // delete: () => Promise<unknown>;
-  // sync: () => Promise<unknown>;
+  // TOOO: Update Response Type to Task Type Response
+  delete: (id: string) => Promise<AxiosResponse<unknown>>;
 }
 
 /**
@@ -81,8 +82,7 @@ function createRepositoryAPI(base: PulpAPI): RPMRepositoryClient {
     create: (data) => base.http.post(`repositories/rpm/rpm/`, data),
     update: (id, data) =>
       base.http.patch(`repositories/rpm/rpm/${id}`, { data }),
-    // delete: () => {},
-    // sync: () => {},
+    delete: (id) => base.http.delete(`repositories/rpm/rpm/${id}`),
   };
 }
 

--- a/src/api/plugins/rpm/repository.ts
+++ b/src/api/plugins/rpm/repository.ts
@@ -1,8 +1,9 @@
 import type { AxiosResponse } from 'axios';
 import type {
-  GenericPaginatedResponse,
+  DispatchedTaskResponse,
   GenericRepository,
   GenericRepositoryFilterParams,
+  PaginatedResponse,
 } from '../../common';
 import type { PulpAPI } from '../../pulp';
 
@@ -49,12 +50,12 @@ interface RPMRepositoryUpsertType extends Omit<
   checksum_type?: RPMAllowedUpsertChecksumsType | null;
 }
 
-// FIXME: Move AxiosResponse type to PulpAPI Base Class. 
+// FIXME: Move AxiosResponse type to PulpAPI Base Class.
 // NOTE: The FIXME implementation is not easy as to avoid major type issues with legacy API calls.
 interface RPMRepositoryClient {
   list: (
     params?: GenericRepositoryFilterParams,
-  ) => Promise<AxiosResponse<GenericPaginatedResponse<RPMRepositoryType>>>;
+  ) => Promise<AxiosResponse<PaginatedResponse<RPMRepositoryType>>>;
   retrieve: (id: string) => Promise<AxiosResponse<RPMRepositoryType>>;
   create: (
     data: RPMRepositoryUpsertType,
@@ -62,10 +63,8 @@ interface RPMRepositoryClient {
   update: (
     id: string,
     data: Partial<RPMRepositoryUpsertType>,
-    // TODO: Update Response Type to union of Upsert Type & Task Type
-  ) => Promise<AxiosResponse<RPMRepositoryUpsertType>>;
-  // TOOO: Update Response Type to Task Type Response
-  delete: (id: string) => Promise<AxiosResponse<unknown>>;
+  ) => Promise<AxiosResponse<RPMRepositoryUpsertType | DispatchedTaskResponse>>;
+  delete: (id: string) => Promise<AxiosResponse<DispatchedTaskResponse>>;
 }
 
 /**
@@ -78,11 +77,10 @@ interface RPMRepositoryClient {
 function createRepositoryAPI(base: PulpAPI): RPMRepositoryClient {
   return {
     list: (params?) => base.list(`repositories/rpm/rpm/`, params),
-    retrieve: (id) => base.http.get(`repositories/rpm/rpm/${id}`),
+    retrieve: (id) => base.http.get(`repositories/rpm/rpm/${id}/`),
     create: (data) => base.http.post(`repositories/rpm/rpm/`, data),
-    update: (id, data) =>
-      base.http.patch(`repositories/rpm/rpm/${id}`, { data }),
-    delete: (id) => base.http.delete(`repositories/rpm/rpm/${id}`),
+    update: (id, data) => base.http.patch(`repositories/rpm/rpm/${id}/`, data),
+    delete: (id) => base.http.delete(`repositories/rpm/rpm/${id}/`),
   };
 }
 

--- a/src/api/plugins/rpm/repository.ts
+++ b/src/api/plugins/rpm/repository.ts
@@ -1,0 +1,67 @@
+import type { AxiosResponse } from 'axios';
+import type {
+  GenericPaginatedResponse,
+  GenericRepository,
+  GenericRepositoryFilterParams,
+} from '../../common';
+import type { PulpAPI } from '../../pulp';
+
+type RPMChecksumType =
+  | 'unknown'
+  | 'md5'
+  | 'sha'
+  | 'sha1'
+  | 'sha224'
+  | 'sha256'
+  | 'sha384'
+  | 'sha512';
+type RPMCompressionType = 'zstd' | 'gz' | 'none';
+type RPMLayoutType = 'nested_alphabetically' | 'flat' | 'nested_by_digest';
+
+/**
+ * RPM Repository Type.
+ *
+ * @see https://github.com/pulp/pulp_rpm/blob/dc333a99db6c44d70d6103540cb592f6e55a8682/pulp_rpm/app/serializers/repository.py#L177
+ */
+interface RPMRepositoryType extends GenericRepository {
+  autopublish?: boolean;
+  metadata_signing_service?: string | null;
+  package_signing_service?: string | null;
+  package_signing_fingerprint?: string | null;
+  retain_package_versions?: number;
+  checksum_type?: RPMChecksumType | null;
+  compression_type?: RPMCompressionType | null;
+  layout?: RPMLayoutType | null;
+  repo_config?: Record<string, unknown>;
+  osv_config?: { name: string; releases: unknown }[] | null;
+}
+
+interface RPMRepositoryClient {
+  list: (
+    params?: GenericRepositoryFilterParams,
+    // FIXME: Move AxiosResponse type to PulpAPI Base Class.
+  ) => Promise<AxiosResponse<GenericPaginatedResponse<RPMRepositoryType[]>>>;
+  // retrieve: () => Promise<unknown>;
+  // create: () => Promise<unknown>;
+  // update: () => Promise<unknown>;
+}
+
+/**
+ * RPM Repository API Client
+ * @param {PulpAPI} base
+ * @returns {RPMRepositoryClient}
+ *
+ * @see https://github.com/pulp/pulp_rpm/blob/dc333a99db6c44d70d6103540cb592f6e55a8682/pulp_rpm/app/viewsets/repository.py#L76
+ */
+function createRepositoryAPI(base: PulpAPI): RPMRepositoryClient {
+  return {
+    list: (params?: GenericRepositoryFilterParams) =>
+      base.list(`repositories/rpm/rpm/`, params),
+    // retrieve: () => {},
+    // create: () => {},
+    // update: () => {},
+  };
+}
+
+export { createRepositoryAPI };
+export type { RPMRepositoryType };

--- a/src/api/plugins/rpm/repository.ts
+++ b/src/api/plugins/rpm/repository.ts
@@ -6,19 +6,12 @@ import type {
   PaginatedResponse,
 } from '../../common';
 import type { PulpAPI } from '../../pulp';
-
-type RPMChecksumType =
-  | 'unknown'
-  | 'md5'
-  | 'sha'
-  | 'sha1'
-  | 'sha224'
-  | 'sha256'
-  | 'sha384'
-  | 'sha512';
-type RPMAllowedUpsertChecksumsType = 'sha256' | 'sha384' | 'sha512';
-type RPMCompressionType = 'zstd' | 'gz' | 'none';
-type RPMLayoutType = 'nested_alphabetically' | 'flat' | 'nested_by_digest';
+import type {
+  RPMAllowedUpsertChecksumsType,
+  RPMChecksumType,
+  RPMCompressionType,
+  RPMLayoutType,
+} from './types';
 
 /**
  * RPM Repository Type.

--- a/src/api/plugins/rpm/repository.ts
+++ b/src/api/plugins/rpm/repository.ts
@@ -36,12 +36,14 @@ interface RPMRepositoryType extends GenericRepository {
   osv_config?: { name: string; releases: unknown }[] | null;
 }
 
+// FIXME: Move AxiosResponse type to PulpAPI Base Class.
 interface RPMRepositoryClient {
   list: (
     params?: GenericRepositoryFilterParams,
-    // FIXME: Move AxiosResponse type to PulpAPI Base Class.
-  ) => Promise<AxiosResponse<GenericPaginatedResponse<RPMRepositoryType[]>>>;
-  // retrieve: () => Promise<unknown>;
+  ) => Promise<AxiosResponse<GenericPaginatedResponse<RPMRepositoryType>>>;
+  retrieve: (
+    id: string,
+  ) => Promise<AxiosResponse<RPMRepositoryType>>;
   // create: () => Promise<unknown>;
   // update: () => Promise<unknown>;
 }
@@ -55,9 +57,9 @@ interface RPMRepositoryClient {
  */
 function createRepositoryAPI(base: PulpAPI): RPMRepositoryClient {
   return {
-    list: (params?: GenericRepositoryFilterParams) =>
+    list: (params?) =>
       base.list(`repositories/rpm/rpm/`, params),
-    // retrieve: () => {},
+    retrieve: (id) => base.http.get(`repositories/rpm/rpm/${id}`),
     // create: () => {},
     // update: () => {},
   };

--- a/src/api/plugins/rpm/repository.ts
+++ b/src/api/plugins/rpm/repository.ts
@@ -15,6 +15,7 @@ type RPMChecksumType =
   | 'sha256'
   | 'sha384'
   | 'sha512';
+type RPMAllowedUpsertChecksumsType = 'sha256' | 'sha384' | 'sha512';
 type RPMCompressionType = 'zstd' | 'gz' | 'none';
 type RPMLayoutType = 'nested_alphabetically' | 'flat' | 'nested_by_digest';
 
@@ -36,16 +37,34 @@ interface RPMRepositoryType extends GenericRepository {
   osv_config?: { name: string; releases: unknown }[] | null;
 }
 
+/**
+ * RPM Create / Update Type.
+ * 
+ * @see https://github.com/pulp/pulp_rpm/blob/dc333a99db6c44d70d6103540cb592f6e55a8682/pulp_rpm/app/serializers/repository.py#L326
+ */
+interface RPMRepositoryUpsertType extends Omit<
+  RPMRepositoryType,
+  'checksum_type'
+> {
+  checksum_type?: RPMAllowedUpsertChecksumsType | null;
+}
+
 // FIXME: Move AxiosResponse type to PulpAPI Base Class.
 interface RPMRepositoryClient {
   list: (
     params?: GenericRepositoryFilterParams,
   ) => Promise<AxiosResponse<GenericPaginatedResponse<RPMRepositoryType>>>;
-  retrieve: (
+  retrieve: (id: string) => Promise<AxiosResponse<RPMRepositoryType>>;
+  create: (
+    data: RPMRepositoryUpsertType,
+  ) => Promise<AxiosResponse<RPMRepositoryUpsertType>>;
+  update: (
     id: string,
-  ) => Promise<AxiosResponse<RPMRepositoryType>>;
-  // create: () => Promise<unknown>;
-  // update: () => Promise<unknown>;
+    data: Partial<RPMRepositoryUpsertType>,
+    // TODO: Update Reponse Type
+  ) => Promise<AxiosResponse<RPMRepositoryUpsertType>>;
+  // delete: () => Promise<unknown>;
+  // sync: () => Promise<unknown>;
 }
 
 /**
@@ -57,13 +76,15 @@ interface RPMRepositoryClient {
  */
 function createRepositoryAPI(base: PulpAPI): RPMRepositoryClient {
   return {
-    list: (params?) =>
-      base.list(`repositories/rpm/rpm/`, params),
+    list: (params?) => base.list(`repositories/rpm/rpm/`, params),
     retrieve: (id) => base.http.get(`repositories/rpm/rpm/${id}`),
-    // create: () => {},
-    // update: () => {},
+    create: (data) => base.http.post(`repositories/rpm/rpm/`, data),
+    update: (id, data) =>
+      base.http.patch(`repositories/rpm/rpm/${id}`, { data }),
+    // delete: () => {},
+    // sync: () => {},
   };
 }
 
 export { createRepositoryAPI };
-export type { RPMRepositoryType };
+export type { RPMRepositoryType, RPMRepositoryUpsertType };

--- a/src/api/plugins/rpm/types.ts
+++ b/src/api/plugins/rpm/types.ts
@@ -1,0 +1,21 @@
+type RPMChecksumType =
+  | 'unknown'
+  | 'md5'
+  | 'sha'
+  | 'sha1'
+  | 'sha224'
+  | 'sha256'
+  | 'sha384'
+  | 'sha512';
+type RPMAllowedUpsertChecksumsType = 'sha256' | 'sha384' | 'sha512';
+
+type RPMCompressionType = 'zstd' | 'gz' | 'none';
+
+type RPMLayoutType = 'nested_alphabetically' | 'flat' | 'nested_by_digest';
+
+export type {
+  RPMChecksumType,
+  RPMAllowedUpsertChecksumsType,
+  RPMCompressionType,
+  RPMLayoutType,
+};

--- a/src/api/response-types/remote.ts
+++ b/src/api/response-types/remote.ts
@@ -3,7 +3,7 @@ import { type PulpStatus } from './pulp';
 /**
  * @deprecated
  * Use `LastSyncType` from `common.ts` instead.
- * 
+ *
  * Known issue: `started_at` doesn't match real API field, and `finished_at` / `error` are actually nullable.
  */
 export class LastSyncType {

--- a/src/api/response-types/remote.ts
+++ b/src/api/response-types/remote.ts
@@ -1,5 +1,11 @@
 import { type PulpStatus } from './pulp';
 
+/**
+ * @deprecated
+ * Use `LastSyncType` from `common.ts` instead.
+ * 
+ * Known issue: `started_at` doesn't match real API field, and `finished_at` / `error` are actually nullable.
+ */
 export class LastSyncType {
   state: PulpStatus;
   started_at: string;

--- a/src/api/response-types/remote.ts
+++ b/src/api/response-types/remote.ts
@@ -1,11 +1,5 @@
 import { type PulpStatus } from './pulp';
 
-/**
- * @deprecated
- * Use `LastSyncType` from `common.ts` instead.
- *
- * Known issue: `started_at` doesn't match real API field, and `finished_at` / `error` are actually nullable.
- */
 export class LastSyncType {
   state: PulpStatus;
   started_at: string;

--- a/src/api/rpm-repository.ts
+++ b/src/api/rpm-repository.ts
@@ -1,13 +1,21 @@
 import type { GenericRepository } from './common';
 import { PulpAPI } from './pulp';
 
-type RPMChecksumType = "unknown" | "md5" | "sha" | "sha1" | "sha224" | "sha256" | "sha384" | "sha512";
-type RPMCompressionType = "zstd" | "gz" | "none";
-type RPMLayoutType = "nested_alphabetically" | "flat" | "nested_by_digest";
+type RPMChecksumType =
+  | 'unknown'
+  | 'md5'
+  | 'sha'
+  | 'sha1'
+  | 'sha224'
+  | 'sha256'
+  | 'sha384'
+  | 'sha512';
+type RPMCompressionType = 'zstd' | 'gz' | 'none';
+type RPMLayoutType = 'nested_alphabetically' | 'flat' | 'nested_by_digest';
 
 /**
  * RPM Repository Type.
- * 
+ *
  * @see https://github.com/pulp/pulp_rpm/blob/main/pulp_rpm/app/serializers/repository.py
  */
 interface RPMRepositoryType extends GenericRepository {

--- a/src/api/rpm-repository.ts
+++ b/src/api/rpm-repository.ts
@@ -1,7 +1,32 @@
+import type { GenericRepository } from './common';
 import { PulpAPI } from './pulp';
+
+type RPMChecksumType = "unknown" | "md5" | "sha" | "sha1" | "sha224" | "sha256" | "sha384" | "sha512";
+type RPMCompressionType = "zstd" | "gz" | "none";
+type RPMLayoutType = "nested_alphabetically" | "flat" | "nested_by_digest";
+
+/**
+ * RPM Repository Type.
+ * 
+ * @see https://github.com/pulp/pulp_rpm/blob/main/pulp_rpm/app/serializers/repository.py
+ */
+interface RPMRepositoryType extends GenericRepository {
+  autopublish?: boolean;
+  metadata_signing_service?: string | null;
+  package_signing_service?: string | null;
+  package_signing_fingerprint?: string | null;
+  retain_package_versions?: number;
+  checksum_type?: RPMChecksumType | null;
+  compression_type?: RPMCompressionType | null;
+  layout?: RPMLayoutType | null;
+  repo_config?: Record<string, unknown>;
+  osv_config?: { name: string; releases: unknown }[] | null;
+}
 
 const base = new PulpAPI();
 
 export const RPMRepositoryAPI = {
   list: (params?) => base.list(`repositories/rpm/rpm/`, params),
 };
+
+export type { RPMRepositoryType };

--- a/src/api/rpm-repository.ts
+++ b/src/api/rpm-repository.ts
@@ -1,40 +1,10 @@
-import type { GenericRepository } from './common';
 import { PulpAPI } from './pulp';
-
-type RPMChecksumType =
-  | 'unknown'
-  | 'md5'
-  | 'sha'
-  | 'sha1'
-  | 'sha224'
-  | 'sha256'
-  | 'sha384'
-  | 'sha512';
-type RPMCompressionType = 'zstd' | 'gz' | 'none';
-type RPMLayoutType = 'nested_alphabetically' | 'flat' | 'nested_by_digest';
-
-/**
- * RPM Repository Type.
- *
- * @see https://github.com/pulp/pulp_rpm/blob/main/pulp_rpm/app/serializers/repository.py
- */
-interface RPMRepositoryType extends GenericRepository {
-  autopublish?: boolean;
-  metadata_signing_service?: string | null;
-  package_signing_service?: string | null;
-  package_signing_fingerprint?: string | null;
-  retain_package_versions?: number;
-  checksum_type?: RPMChecksumType | null;
-  compression_type?: RPMCompressionType | null;
-  layout?: RPMLayoutType | null;
-  repo_config?: Record<string, unknown>;
-  osv_config?: { name: string; releases: unknown }[] | null;
-}
 
 const base = new PulpAPI();
 
+/**
+ * @deprecated Use `RpmClient` from `src/api/plugins/rpm/client.ts` instead.
+ */
 export const RPMRepositoryAPI = {
   list: (params?) => base.list(`repositories/rpm/rpm/`, params),
 };
-
-export type { RPMRepositoryType };

--- a/src/api/test-utils/integration-client.ts
+++ b/src/api/test-utils/integration-client.ts
@@ -103,4 +103,9 @@ async function waitForTaskCompletion(
 
 const extractIdentifierFromPrn = (prn: string): string => prn.split(':', 3)[2];
 
-export { testPulpAPI, testAxiosClient, waitForTaskCompletion, extractIdentifierFromPrn };
+export {
+  testPulpAPI,
+  testAxiosClient,
+  waitForTaskCompletion,
+  extractIdentifierFromPrn,
+};

--- a/src/api/test-utils/integration-client.ts
+++ b/src/api/test-utils/integration-client.ts
@@ -42,11 +42,12 @@ function testPulpAPI(): PulpAPI {
         testAxiosClient(url, { method: 'POST', data }),
       patch: (
         url: string,
-        config: { params?: Record<string, unknown>; data: unknown },
+        data: unknown,
+        config: { params?: Record<string, unknown> },
       ) =>
         testAxiosClient(`${url}${buildQueryParams(config?.params)}`, {
           method: 'PATCH',
-          data: config.data,
+          data,
         }),
       delete: (url: string, config: { params?: Record<string, unknown> }) =>
         testAxiosClient(`${url}${buildQueryParams(config?.params)}`, {
@@ -79,18 +80,18 @@ async function waitForTaskCompletion(
   const res = await testAxiosClient(taskHref, { method: 'GET' });
   const state: string = res.data.state;
 
-  // TODO: Update Error Message
   if (['skipped', 'failed', 'canceled'].includes(state)) {
-    throw new Error('Another Error');
+    throw new Error(`Task ${taskHref} ended with state "${state}"`);
   }
 
   if (state === 'completed') {
     return;
   }
 
-  // TODO: Update Error Message
   if (attemptsLeft <= 0) {
-    throw new Error(`Task did not complete`);
+    throw new Error(
+      `Task ${taskHref} did not complete within the allowed attempts`,
+    );
   }
 
   await new Promise((r) => setTimeout(r, waitMs));

--- a/src/api/test-utils/integration-client.ts
+++ b/src/api/test-utils/integration-client.ts
@@ -103,9 +103,43 @@ async function waitForTaskCompletion(
 
 const extractIdentifierFromPrn = (prn: string): string => prn.split(':', 3)[2];
 
+async function createAndWaitForResource<TResult>(
+  url: string,
+  data: Record<string, unknown>,
+): Promise<TResult> {
+  const res = await testAxiosClient(url, {
+    method: 'POST',
+    data: JSON.stringify(data),
+  });
+
+  if (res.data.pulp_href) {
+    return res.data;
+  }
+
+  if (res.data.task) {
+    await waitForTaskCompletion(res.data.task);
+    const task = await testAxiosClient(res.data.task, { method: 'GET' });
+    const href = task.data.created_resources?.[0];
+
+    if (!href) {
+      throw new Error(
+        `Failed to resolve created resource href from task ${res.data.task}`,
+      );
+    }
+
+    const resource = await testAxiosClient(href, { method: 'GET' });
+    return resource.data;
+  }
+
+  throw new Error(
+    `Failed to reate resource at ${url}: unexpected response shape`,
+  );
+}
+
 export {
   testPulpAPI,
   testAxiosClient,
   waitForTaskCompletion,
   extractIdentifierFromPrn,
+  createAndWaitForResource,
 };

--- a/src/api/test-utils/integration-client.ts
+++ b/src/api/test-utils/integration-client.ts
@@ -1,0 +1,58 @@
+import axios, { type AxiosRequestConfig, type AxiosResponse } from 'axios';
+import { type PulpAPI } from '../pulp';
+
+const baseUrl: string =
+  process.env.PULP_BASE_URL ?? 'http://localhost:8080/pulp/api/v3/';
+const testUsername: string = process.env.PULP_USERNAME ?? 'admin';
+const testPassword: string = process.env.PULP_PASSWORD ?? 'admin';
+const authorization: string =
+  'Basic ' + Buffer.from(`${testUsername}:${testPassword}`).toString('base64');
+
+async function testAxiosClient(
+  path: string,
+  config: AxiosRequestConfig = {},
+): Promise<AxiosResponse> {
+  const url: string = new URL(path, baseUrl).toString();
+  const axiosRequest = {
+    ...config,
+    url,
+    headers: {
+      Authorization: authorization,
+      'Content-Type': 'application/json',
+      ...config.headers,
+    },
+  } satisfies AxiosRequestConfig;
+  const res = await axios.request(axiosRequest);
+
+  return res;
+}
+
+function testPulpAPI(): PulpAPI {
+  return {
+    list: (url: string, params?: Record<string, unknown>) =>
+      testAxiosClient(`${url}${buildQueryParams(params)}`, {
+        method: 'GET',
+      }),
+    http: {
+      get: (url: string, config: { params?: Record<string, unknown> }) =>
+        testAxiosClient(`${url}${buildQueryParams(config?.params)}`, {
+          method: 'GET',
+        }),
+    },
+  } as unknown as PulpAPI;
+}
+
+function buildQueryParams(params?: Record<string, unknown>): string {
+  const search = new URLSearchParams();
+
+  for (const [key, value] of Object.entries(params ?? {})) {
+    if (value !== undefined) {
+      search.set(key, String(value));
+    }
+  }
+
+  const queryString = search.toString();
+  return queryString ? `?${queryString}` : '';
+}
+
+export { testPulpAPI, testAxiosClient };

--- a/src/api/test-utils/integration-client.ts
+++ b/src/api/test-utils/integration-client.ts
@@ -101,4 +101,6 @@ async function waitForTaskCompletion(
   });
 }
 
-export { testPulpAPI, testAxiosClient, waitForTaskCompletion };
+const extractIdentifierFromPrn = (prn: string): string => prn.split(':', 3)[2];
+
+export { testPulpAPI, testAxiosClient, waitForTaskCompletion, extractIdentifierFromPrn };

--- a/src/api/test-utils/integration-client.ts
+++ b/src/api/test-utils/integration-client.ts
@@ -48,6 +48,10 @@ function testPulpAPI(): PulpAPI {
           method: 'PATCH',
           data: config.data,
         }),
+      delete: (url: string, config: { params?: Record<string, unknown> }) =>
+        testAxiosClient(`${url}${buildQueryParams(config?.params)}`, {
+          method: 'DELETE',
+        }),
     },
   } as unknown as PulpAPI;
 }
@@ -65,4 +69,35 @@ function buildQueryParams(params?: Record<string, unknown>): string {
   return queryString ? `?${queryString}` : '';
 }
 
-export { testPulpAPI, testAxiosClient };
+async function waitForTaskCompletion(
+  taskHref: string,
+  {
+    waitMs = 500,
+    attemptsLeft = 10,
+  }: { waitMs?: number; attemptsLeft?: number } = {},
+): Promise<void> {
+  const res = await testAxiosClient(taskHref, { method: 'GET' });
+  const state: string = res.data.state;
+
+  // TODO: Update Error Message
+  if (['skipped', 'failed', 'canceled'].includes(state)) {
+    throw new Error('Another Error');
+  }
+
+  if (state === 'completed') {
+    return;
+  }
+
+  // TODO: Update Error Message
+  if (attemptsLeft <= 0) {
+    throw new Error(`Task did not complete`);
+  }
+
+  await new Promise((r) => setTimeout(r, waitMs));
+  return waitForTaskCompletion(taskHref, {
+    waitMs: Math.round(waitMs * 1.5),
+    attemptsLeft: attemptsLeft - 1,
+  });
+}
+
+export { testPulpAPI, testAxiosClient, waitForTaskCompletion };

--- a/src/api/test-utils/integration-client.ts
+++ b/src/api/test-utils/integration-client.ts
@@ -1,5 +1,5 @@
 import axios, { type AxiosRequestConfig, type AxiosResponse } from 'axios';
-import { type PulpAPI } from '../pulp';
+import type { PulpAPI } from '../pulp.ts';
 
 const baseUrl: string =
   process.env.PULP_BASE_URL ?? 'http://localhost:8080/pulp/api/v3/';
@@ -37,6 +37,16 @@ function testPulpAPI(): PulpAPI {
       get: (url: string, config: { params?: Record<string, unknown> }) =>
         testAxiosClient(`${url}${buildQueryParams(config?.params)}`, {
           method: 'GET',
+        }),
+      post: (url: string, data: unknown) =>
+        testAxiosClient(url, { method: 'POST', data }),
+      patch: (
+        url: string,
+        config: { params?: Record<string, unknown>; data: unknown },
+      ) =>
+        testAxiosClient(`${url}${buildQueryParams(config?.params)}`, {
+          method: 'PATCH',
+          data: config.data,
         }),
     },
   } as unknown as PulpAPI;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     "lib": ["es2021", "dom"],
     "module": "es2020",
     "moduleResolution": "node",
+    "allowImportingTsExtensions": true,
     "noImplicitAny": false,
     "outDir": "./dist/",
     "paths": {


### PR DESCRIPTION
## Summary
Built out a fully-typed API client for RPM publications, extending the pattern from RPM Repository, Remote, and Distribution clients. Covers the CRDL endpoints `RpmPublicationViewSet` and models against Pulp Core.

## Changes
1. Added typed RPM Publication API client (list, retrieve, create, delete) built off `RpmPublicationSerializer`.
2. Added `RPMPublicationUpsertType` for narrowing `checksum_tpye` similar to RPM Repository client.
3. Added `GenericPublicationFilterParams` to `common.ts` for filtering.
4. Extracted shared RPM enum types into a new `plugins/rpm/types.ts` file.
5. Added integration tests against a live Pulp instance using `node:test`.

## Out of Scope
1. UI/component consumption of this client.

### Blockers (In order)
1. https://github.com/pulp/pulp-ui/pull/307
2. https://github.com/pulp/pulp-ui/pull/308
3. https://github.com/pulp/pulp-ui/pull/311
4. https://github.com/pulp/pulp-ui/pull/312

### Linked issue
1. https://github.com/pulp/pulp-ui/issues/309

## Sources
1. https://github.com/pulp/pulpcore
2. https://github.com/pulp/pulp_rpm