### PR TITLE
PulpStatus - fix storage gauge when the backend reports no capacity

### DIFF
--- a/src/containers/pulp-status.tsx
+++ b/src/containers/pulp-status.tsx
@@ -132,33 +132,57 @@ const StatusRedisConnection = ({
   redisConnection: { connected: boolean };
 }) => (redisConnection?.connected ? t`Connected` : `Not connected`);
 
-const StatusStorage = ({ storage }: { storage: { total; used; free } }) => {
-  const value = (100 / storage.total) * storage.used;
-  const total = getHumanSize(storage.total);
-  const used = getHumanSize(storage.used);
-  const free = getHumanSize(storage.free);
+// pulpcore measures total and free space only when artifacts live on a
+// filesystem. Every other backend reports both as null -- an object store has no
+// capacity to measure -- and `storage` itself is null if the filesystem lookup
+// raises. See _disk_usage() in pulpcore/app/views/status.py; the corresponding
+// serializer fields are allow_null=True.
+const isMeasured = (value): value is number =>
+  typeof value === 'number' && Number.isFinite(value);
+
+const StatusStorage = ({
+  storage,
+}: {
+  storage?: { total?: number; used?: number; free?: number };
+}) => {
+  const { total, used, free } = storage ?? {};
+
+  // Only a real capacity makes a percentage meaningful. Without this guard
+  // `(100 / null) * used` is Infinity, which Progress clamps to a full red bar,
+  // reporting every object-storage install as out of space.
+  const percentage =
+    isMeasured(total) && total > 0 && isMeasured(used)
+      ? (100 / total) * used
+      : null;
+
+  const size = (value) =>
+    isMeasured(value) ? getHumanSize(value) : t`Not reported`;
 
   return (
     <>
-      <Progress
-        value={value}
-        title={t`Storage`}
-        variant={
-          value > 88
-            ? 'danger'
-            : value > 66
-              ? 'warning'
-              : value > 33
-                ? null
-                : 'success'
-        }
-      />
+      {percentage === null ? null : (
+        <>
+          <Progress
+            value={percentage}
+            title={t`Storage`}
+            variant={
+              percentage > 88
+                ? 'danger'
+                : percentage > 66
+                  ? 'warning'
+                  : percentage > 33
+                    ? null
+                    : 'success'
+            }
+          />
+          <br />
+        </>
+      )}
+      <strong>{t`Total`}</strong>: {size(total)}
       <br />
-      <strong>{t`Total`}</strong>: {total}
+      <strong>{t`Used`}</strong>: {size(used)}
       <br />
-      <strong>{t`Used`}</strong>: {used}
-      <br />
-      <strong>{t`Free`}</strong>: {free}
+      <strong>{t`Free`}</strong>: {size(free)}
     </>
   );
 };


### PR DESCRIPTION
## Problem

On any install that keeps artifacts in object storage, the Status page reports storage as a **red, 100%-full gauge with `Total: 0 bytes` and `Free: 0 bytes`** — regardless of how little is actually stored.

Reproduced on pulpcore 3.116.0 with a Ceph RGW (S3) backend. `/pulp/api/v3/status/` returns:

```json
{
  "storage": {
    "total": null,
    "used": 188976272,
    "free": null
  }
}
```

## Cause

`null` here is the documented API contract, not an error. `_disk_usage()` in `pulpcore/app/views/status.py` only measures real capacity for filesystem storage:

```python
def _disk_usage():
    domain = get_domain()
    if domain.storage_class == "pulpcore.app.models.storage.FileSystem":
        storage = domain.get_storage()
        try:
            return shutil.disk_usage(storage.location)
        except Exception:
            _logger.exception(_("Failed to determine disk usage"))
    else:
        used = Artifact.objects.filter(pulp_domain=domain).aggregate(size=Sum("size", default=0))
        return StorageSpace(None, used["size"], None)
```

An object store has no capacity to measure, so `total` and `free` are `None` — and `StorageSerializer` declares both `allow_null=True`.

`StatusStorage` doesn't handle that:

- `(100 / null) * used` → `null` coerces to `0` → **`Infinity`**. `Progress` clamps that to a full bar, and the variant ladder reads `Infinity > 88` as **`danger`**, hence red and full.
- `getHumanSize(null)` → `parseInt(null, 10) || 0` → `0` → **`"0 bytes"`** for both Total and Free.

There's a second, related problem on the filesystem path: if `shutil.disk_usage()` raises, `_disk_usage()` falls through and returns `None`, so `storage` itself is `null`. `storage.total` then throws a `TypeError` that blanks the entire Status page.

## Fix

Draw the gauge only when there is a capacity to draw a percentage against, and report unmeasured fields as `Not reported` rather than as zero. The filesystem case is untouched.

| `status.storage` | before | after |
|---|---|---|
| `{total: null, used: 188976272, free: null}` | `Infinity`, `variant=danger`, `Total: 0 bytes`, `Free: 0 bytes` | gauge hidden, `Total: Not reported`, `Used: 180 MiB`, `Free: Not reported` |
| `{total: 107374182400, used: 53687091200, free: 53687091200}` | `50%` | `50%` (unchanged) |
| `null` | `TypeError` — blank page | gauge hidden, all three `Not reported` |

I deliberately left `getHumanSize()` alone: it's shared with the execution-environment views, which pass real numbers, so distinguishing "unmeasured" from "zero" belongs at this call site rather than in the shared helper.

No `CHANGES.md` entry, since that file is generated from PR titles by the release workflow.

## Testing

- `npm run lint:js`, `npm run lint:ts`, `npm run lint:ls` — clean
- `npm run build` — succeeds (only the pre-existing bundle-size warnings)
- Verified against a live pulpcore 3.116.0 on Ceph RGW, and against the filesystem and `null` payload shapes above

Happy to adjust the `Not reported` wording, or to show a plain "Used: X" line without the labels for the unmeasured case, if maintainers prefer.